### PR TITLE
Verifies building of URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add tests to verify DateTime and DateTimeOffsets default to ISO 8601.
+- Adds check to return error when the baseUrl path parameter is not set when needed.
+
 ### Changed
 
 ## [0.8.1] - 2022-06-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+## [0.8.2] - 2022-08-11
+
+### Added
+
 - Add tests to verify DateTime and DateTimeOffsets default to ISO 8601.
 - Adds check to return error when the baseUrl path parameter is not set when needed.
-
-### Changed
 
 ## [0.8.1] - 2022-06-07
 

--- a/request_information.go
+++ b/request_information.go
@@ -63,6 +63,11 @@ func (request *RequestInformation) GetUri() (*u.URL, error) {
 		request.SetUri(*uri)
 		return request.uri, nil
 	} else {
+		_, baseurlExists := request.PathParameters["baseurl"]
+		if strings.Contains(strings.ToLower(request.UrlTemplate), "{+baseurl}") && !baseurlExists {
+			return nil, errors.New("pathParameters must contain a value for \"baseurl\" for the url to be built")
+		}
+
 		uriTemplate, err := t.New(request.UrlTemplate)
 		if err != nil {
 			return nil, err
@@ -202,7 +207,7 @@ func (request *RequestInformation) SetContentFromParsable(requestAdapter Request
 	return nil
 }
 
-// SetContentFromParsable sets the request body from a scalar value with the specified content type.
+// SetContentFromScalar sets the request body from a scalar value with the specified content type.
 func (request *RequestInformation) SetContentFromScalar(requestAdapter RequestAdapter, contentType string, items ...interface{}) error {
 	writer, err := request.getSerializationWriter(requestAdapter, contentType, items...)
 	if err != nil {

--- a/request_information.go
+++ b/request_information.go
@@ -64,7 +64,7 @@ func (request *RequestInformation) GetUri() (*u.URL, error) {
 		return request.uri, nil
 	} else {
 		_, baseurlExists := request.PathParameters["baseurl"]
-		if strings.Contains(strings.ToLower(request.UrlTemplate), "{+baseurl}") && !baseurlExists {
+		if !baseurlExists && strings.Contains(strings.ToLower(request.UrlTemplate), "{+baseurl}") {
 			return nil, errors.New("pathParameters must contain a value for \"baseurl\" for the url to be built")
 		}
 

--- a/request_information_test.go
+++ b/request_information_test.go
@@ -2,6 +2,7 @@ package abstractions
 
 import (
 	"testing"
+	"time"
 
 	assert "github.com/stretchr/testify/assert"
 )
@@ -80,13 +81,50 @@ type getQueryParameters struct {
 	Search         *string  `uriparametername:"%24search"`
 }
 
-func TestItSetsSelectQueryParameters(t *testing.T) {
+func TestItSetsSelectAndCountQueryParameters(t *testing.T) {
+	value := true
 	requestInformation := NewRequestInformation()
-	requestInformation.UrlTemplate = "http://localhost/me{?%24select}"
+	requestInformation.UrlTemplate = "http://localhost/me{?%24select,%24count}"
 	requestInformation.AddQueryParameters(getQueryParameters{
 		Select_escaped: []string{"id", "displayName"},
+		Count:          &value,
 	})
 	resultUri, err := requestInformation.GetUri()
 	assert.Nil(t, err)
-	assert.Equal(t, "http://localhost/me?%24select=id%2CdisplayName", resultUri.String())
+	assert.Equal(t, "http://localhost/me?%24select=id%2CdisplayName&%24count=true", resultUri.String())
+}
+
+func TestItSetsPathParametersOfDateTimeOffsetType(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/getDirectRoutingCalls(fromDateTime='{fromDateTime}',toDateTime='{toDateTime}')"
+
+	fromDateTime := time.Date(2022, 8, 1, 20, 34, 58, 0, time.UTC)
+	toDateTime := time.Date(2022, 8, 2, 20, 34, 58, 0, time.UTC)
+
+	requestInformation.PathParameters["fromDateTime"] = fromDateTime.Format(time.RFC3339)
+	requestInformation.PathParameters["toDateTime"] = toDateTime.Format(time.RFC3339)
+
+	resultUri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.Contains(t, resultUri.String(), "fromDateTime='2022-08-01T20%3A34%3A58Z'")
+	assert.Contains(t, resultUri.String(), "toDateTime='2022-08-02T20%3A34%3A58Z'")
+}
+
+func TestItErrorsWhenBaseUrlNotSet(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "{+baseurl}/users{?%24count}"
+
+	_, err := requestInformation.GetUri()
+	assert.NotNil(t, err)
+}
+
+func TestItBuildsUrlOnProvidedBaseUrl(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "{+baseurl}/users{?%24count}"
+
+	requestInformation.PathParameters["baseurl"] = "http://localhost"
+
+	resultUri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost/users", resultUri.String())
 }


### PR DESCRIPTION
This PR is related to https://github.com/microsoft/kiota-abstractions-dotnet/pull/30

It verifies URL formats in the case of boolean and Date path parameters are added to the path parameters collection by adding tests to verify the behavior.

As the path parameters collection in Go takes in a string and not an object, control over the conversion of date formats will need to be applied in the generator as the data is placed in the collection.  

Generator PR with fix https://github.com/microsoft/kiota/pull/1778