### PR TITLE
Adds context as parameter for send Async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0] - 2022-08-24
+
+### Changed
+- Changes RequestAdapter contract passing a `Context` object as the first parameter for SendAsync
+
 ## [0.8.2] - 2022-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [1.0.0] - 2022-08-24
+## [0.9.0] - 2022-08-24
 
 ### Changed
 - Changes RequestAdapter contract passing a `Context` object as the first parameter for SendAsync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changes RequestAdapter contract passing a `Context` object as the first parameter for SendAsync
-- Add `ResponseHandler` to `RequestInformation` struct
 
 ## [0.8.2] - 2022-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.0] - 2022-08-24
 
 ### Changed
+
 - Changes RequestAdapter contract passing a `Context` object as the first parameter for SendAsync
 
 ## [0.8.2] - 2022-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changes RequestAdapter contract passing a `Context` object as the first parameter for SendAsync
+- Add `ResponseHandler` to `RequestInformation` struct
 
 ## [0.8.2] - 2022-08-11
 

--- a/authentication/access_token_provider.go
+++ b/authentication/access_token_provider.go
@@ -1,13 +1,14 @@
 package authentication
 
 import (
+	"context"
 	u "net/url"
 )
 
 //AccessTokenProvider returns access tokens.
 type AccessTokenProvider interface {
 	// GetAuthorizationToken returns the access token for the provided url.
-	GetAuthorizationToken(url *u.URL, additionalAuthenticationContext map[string]interface{}) (string, error)
+	GetAuthorizationToken(context context.Context, url *u.URL, additionalAuthenticationContext map[string]interface{}) (string, error)
 	// GetAllowedHostsValidator returns the hosts validator.
 	GetAllowedHostsValidator() *AllowedHostsValidator
 }

--- a/authentication/anonymous_authentication_provider.go
+++ b/authentication/anonymous_authentication_provider.go
@@ -1,12 +1,15 @@
 package authentication
 
-import abs "github.com/microsoft/kiota-abstractions-go"
+import (
+	"context"
+	abs "github.com/microsoft/kiota-abstractions-go"
+)
 
 // AnonymousAuthenticationProvider implements the AuthenticationProvider interface does not perform any authentication.
 type AnonymousAuthenticationProvider struct {
 }
 
 // AuthenticateRequest is a placeholder method that "authenticates" the RequestInformation instance: no-op.
-func (provider *AnonymousAuthenticationProvider) AuthenticateRequest(request *abs.RequestInformation, additionalAuthenticationContext map[string]interface{}) error {
+func (provider *AnonymousAuthenticationProvider) AuthenticateRequest(context context.Context, request *abs.RequestInformation, additionalAuthenticationContext map[string]interface{}) error {
 	return nil
 }

--- a/authentication/authentication_provider.go
+++ b/authentication/authentication_provider.go
@@ -1,11 +1,12 @@
 package authentication
 
 import (
+	"context"
 	abs "github.com/microsoft/kiota-abstractions-go"
 )
 
 // AuthenticationProvider authenticates the RequestInformation request.
 type AuthenticationProvider interface {
 	// AuthenticateRequest authenticates the provided RequestInformation.
-	AuthenticateRequest(request *abs.RequestInformation, additionalAuthenticationContext map[string]interface{}) error
+	AuthenticateRequest(context context.Context, request *abs.RequestInformation, additionalAuthenticationContext map[string]interface{}) error
 }

--- a/authentication/base_bearer_token_authentication_provider.go
+++ b/authentication/base_bearer_token_authentication_provider.go
@@ -1,6 +1,7 @@
 package authentication
 
 import (
+	"context"
 	"errors"
 
 	abs "github.com/microsoft/kiota-abstractions-go"
@@ -21,7 +22,7 @@ func NewBaseBearerTokenAuthenticationProvider(accessTokenProvider AccessTokenPro
 }
 
 // AuthenticateRequest authenticates the provided RequestInformation instance using the provided authorization token callback.
-func (provider *BaseBearerTokenAuthenticationProvider) AuthenticateRequest(request *abs.RequestInformation, additionalAuthenticationContext map[string]interface{}) error {
+func (provider *BaseBearerTokenAuthenticationProvider) AuthenticateRequest(ctx context.Context, request *abs.RequestInformation, additionalAuthenticationContext map[string]interface{}) error {
 	if request == nil {
 		return errors.New("request is nil")
 	}
@@ -41,7 +42,7 @@ func (provider *BaseBearerTokenAuthenticationProvider) AuthenticateRequest(reque
 		if err != nil {
 			return err
 		}
-		token, err := provider.accessTokenProvider.GetAuthorizationToken(uri, additionalAuthenticationContext)
+		token, err := provider.accessTokenProvider.GetAuthorizationToken(ctx, uri, additionalAuthenticationContext)
 		if err != nil {
 			return err
 		}

--- a/authentication/base_bearer_token_authentication_provider_test.go
+++ b/authentication/base_bearer_token_authentication_provider_test.go
@@ -1,6 +1,7 @@
 package authentication
 
 import (
+	"context"
 	u "net/url"
 	"testing"
 
@@ -10,7 +11,7 @@ import (
 type MockAccessTokenProvider struct {
 }
 
-func (m *MockAccessTokenProvider) GetAuthorizationToken(url *u.URL, additionalAuthenticationContext map[string]interface{}) (string, error) {
+func (m *MockAccessTokenProvider) GetAuthorizationToken(ctx context.Context, url *u.URL, additionalAuthenticationContext map[string]interface{}) (string, error) {
 	return "", nil
 }
 func (m *MockAccessTokenProvider) GetAllowedHostsValidator() *AllowedHostsValidator {

--- a/request_adapter.go
+++ b/request_adapter.go
@@ -19,19 +19,19 @@ type ErrorMappings map[string]s.ParsableFactory
 // RequestAdapter is the service responsible for translating abstract RequestInformation into native HTTP requests.
 type RequestAdapter interface {
 	// SendAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model.
-	SendAsync(context context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (s.Parsable, error)
+	SendAsync(context *context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (s.Parsable, error)
 	// SendEnumAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model.
-	SendEnumAsync(context context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
+	SendEnumAsync(context *context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
 	// SendCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
-	SendCollectionAsync(context context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]s.Parsable, error)
+	SendCollectionAsync(context *context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]s.Parsable, error)
 	// SendEnumCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
-	SendEnumCollectionAsync(context context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
+	SendEnumCollectionAsync(context *context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
 	// SendPrimitiveAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
-	SendPrimitiveAsync(context context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
+	SendPrimitiveAsync(context *context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
 	// SendPrimitiveCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model collection.
-	SendPrimitiveCollectionAsync(context context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
+	SendPrimitiveCollectionAsync(context *context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
 	// SendNoContentAsync executes the HTTP request specified by the given RequestInformation with no return content.
-	SendNoContentAsync(context context.Context, requestInfo *RequestInformation, responseHandler ResponseHandler, errorMappings ErrorMappings) error
+	SendNoContentAsync(context *context.Context, requestInfo *RequestInformation, responseHandler ResponseHandler, errorMappings ErrorMappings) error
 	// GetSerializationWriterFactory returns the serialization writer factory currently in use for the request adapter service.
 	GetSerializationWriterFactory() s.SerializationWriterFactory
 	// EnableBackingStore enables the backing store proxies for the SerializationWriters and ParseNodes in use.

--- a/request_adapter.go
+++ b/request_adapter.go
@@ -9,6 +9,7 @@
 package abstractions
 
 import (
+	"context"
 	s "github.com/microsoft/kiota-abstractions-go/serialization"
 )
 
@@ -18,19 +19,19 @@ type ErrorMappings map[string]s.ParsableFactory
 // RequestAdapter is the service responsible for translating abstract RequestInformation into native HTTP requests.
 type RequestAdapter interface {
 	// SendAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model.
-	SendAsync(requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (s.Parsable, error)
+	SendAsync(context context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (s.Parsable, error)
 	// SendEnumAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model.
-	SendEnumAsync(requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
+	SendEnumAsync(context context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
 	// SendCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
-	SendCollectionAsync(requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]s.Parsable, error)
+	SendCollectionAsync(context context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]s.Parsable, error)
 	// SendEnumCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
-	SendEnumCollectionAsync(requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
+	SendEnumCollectionAsync(context context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
 	// SendPrimitiveAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
-	SendPrimitiveAsync(requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
+	SendPrimitiveAsync(context context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
 	// SendPrimitiveCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model collection.
-	SendPrimitiveCollectionAsync(requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
+	SendPrimitiveCollectionAsync(context context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
 	// SendNoContentAsync executes the HTTP request specified by the given RequestInformation with no return content.
-	SendNoContentAsync(requestInfo *RequestInformation, responseHandler ResponseHandler, errorMappings ErrorMappings) error
+	SendNoContentAsync(context context.Context, requestInfo *RequestInformation, responseHandler ResponseHandler, errorMappings ErrorMappings) error
 	// GetSerializationWriterFactory returns the serialization writer factory currently in use for the request adapter service.
 	GetSerializationWriterFactory() s.SerializationWriterFactory
 	// EnableBackingStore enables the backing store proxies for the SerializationWriters and ParseNodes in use.

--- a/request_adapter.go
+++ b/request_adapter.go
@@ -19,19 +19,19 @@ type ErrorMappings map[string]s.ParsableFactory
 // RequestAdapter is the service responsible for translating abstract RequestInformation into native HTTP requests.
 type RequestAdapter interface {
 	// SendAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model.
-	SendAsync(context *context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (s.Parsable, error)
+	SendAsync(context context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (s.Parsable, error)
 	// SendEnumAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model.
-	SendEnumAsync(context *context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
+	SendEnumAsync(context context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
 	// SendCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
-	SendCollectionAsync(context *context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]s.Parsable, error)
+	SendCollectionAsync(context context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]s.Parsable, error)
 	// SendEnumCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
-	SendEnumCollectionAsync(context *context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
+	SendEnumCollectionAsync(context context.Context, requestInfo *RequestInformation, parser s.EnumFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
 	// SendPrimitiveAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
-	SendPrimitiveAsync(context *context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
+	SendPrimitiveAsync(context context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) (interface{}, error)
 	// SendPrimitiveCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model collection.
-	SendPrimitiveCollectionAsync(context *context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
+	SendPrimitiveCollectionAsync(context context.Context, requestInfo *RequestInformation, typeName string, responseHandler ResponseHandler, errorMappings ErrorMappings) ([]interface{}, error)
 	// SendNoContentAsync executes the HTTP request specified by the given RequestInformation with no return content.
-	SendNoContentAsync(context *context.Context, requestInfo *RequestInformation, responseHandler ResponseHandler, errorMappings ErrorMappings) error
+	SendNoContentAsync(context context.Context, requestInfo *RequestInformation, responseHandler ResponseHandler, errorMappings ErrorMappings) error
 	// GetSerializationWriterFactory returns the serialization writer factory currently in use for the request adapter service.
 	GetSerializationWriterFactory() s.SerializationWriterFactory
 	// EnableBackingStore enables the backing store proxies for the SerializationWriters and ParseNodes in use.

--- a/request_information.go
+++ b/request_information.go
@@ -31,8 +31,6 @@ type RequestInformation struct {
 	// The Url template for the current request.
 	UrlTemplate string
 	options     map[string]RequestOption
-	// The Response Handler.
-	ResponseHandler ResponseHandler
 }
 
 const raw_url_key = "request-raw-url"

--- a/request_information.go
+++ b/request_information.go
@@ -31,6 +31,8 @@ type RequestInformation struct {
 	// The Url template for the current request.
 	UrlTemplate string
 	options     map[string]RequestOption
+	// The Response Handler.
+	ResponseHandler ResponseHandler
 }
 
 const raw_url_key = "request-raw-url"


### PR DESCRIPTION
Add Context as the first parameter in all `Send***` functions for `RequestAdapter` interface

Partially addresses https://github.com/microsoftgraph/msgraph-sdk-go/issues/176

Example 

from 

```go
SendAsync(requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (s.Parsable, error)
```

to 


```go
SendAsync(context context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, responseHandler ResponseHandler, errorMappings ErrorMappings) (s.Parsable, error)
```