### PR TITLE
Feat/generic helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.11.0]- 2022-09-20
+
+### Added
+
+- Adds generic helper methods to reduce code duplication for serializer and deserializers
+
 ## [0.10.1] - 2022-09-14
 
 ### Changed

--- a/internal/person.go
+++ b/internal/person.go
@@ -1,0 +1,87 @@
+package internal
+
+import "github.com/microsoft/kiota-abstractions-go/serialization"
+
+type Person struct {
+	displayName    *string
+	callRecord     *CallRecord
+	callRecords    []*CallRecord
+	status         *PersonStatus
+	previousStatus []*PersonStatus
+	cardNumbers    []int
+}
+
+func NewPerson() *Person {
+	return &Person{}
+}
+
+// Entity
+type Entity struct {
+	// Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+	additionalData map[string]interface{}
+	// Read-only.
+	id *string
+}
+
+type CallRecord struct {
+	Entity
+}
+
+func (c *CallRecord) Serialize(writer serialization.SerializationWriter) error {
+	panic("implement me")
+}
+
+func (c *CallRecord) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
+	panic("implement me")
+}
+
+func NewCallRecord() *CallRecord {
+	return &CallRecord{}
+}
+func (u *Person) SetDisplayName(name *string) {
+	u.displayName = name
+}
+
+func (u *Person) GetDisplayName() *string {
+	return u.displayName
+}
+
+func (u *Person) SetCallRecord(record *CallRecord) {
+	u.callRecord = record
+}
+
+func (u *Person) GetCallRecord() *CallRecord {
+	return u.callRecord
+}
+
+func (u *Person) SetCallRecords(records []*CallRecord) {
+	u.callRecords = records
+}
+
+func (u *Person) GetCallRecords() []*CallRecord {
+	return u.callRecords
+}
+
+func (u *Person) SetStatus(personStatus *PersonStatus) {
+	u.status = personStatus
+}
+
+func (u *Person) GetStatus() *PersonStatus {
+	return u.status
+}
+
+func (u *Person) SetPreviousStatus(previousStatus []*PersonStatus) {
+	u.previousStatus = previousStatus
+}
+
+func (u *Person) GetPreviousStatus() []*PersonStatus {
+	return u.previousStatus
+}
+
+func (u *Person) SetCardNumbers(numbers []int) {
+	u.cardNumbers = numbers
+}
+
+func (u *Person) GetCardNumbers() []int {
+	return u.cardNumbers
+}

--- a/internal/person_status.go
+++ b/internal/person_status.go
@@ -1,0 +1,33 @@
+package internal
+
+import "errors"
+
+type PersonStatus int
+
+const (
+	ACTIVE PersonStatus = iota
+	SUSPEND
+)
+
+func (i PersonStatus) String() string {
+	return []string{"active", "suspended"}[i]
+}
+func ParsePersonStatus(v string) (interface{}, error) {
+	result := ACTIVE
+	switch v {
+	case "active":
+		result = ACTIVE
+	case "suspended":
+		result = SUSPEND
+	default:
+		return 0, errors.New("Unknown PersonStatus value: " + v)
+	}
+	return &result, nil
+}
+func SerializeTeamVisibilityType(values []PersonStatus) []string {
+	result := make([]string, len(values))
+	for i, v := range values {
+		result[i] = v.String()
+	}
+	return result
+}

--- a/serialization/parsable.go
+++ b/serialization/parsable.go
@@ -13,3 +13,6 @@ type ParsableFactory func(parseNode ParseNode) (Parsable, error)
 
 // EnumFactory is a factory for creating Enum.
 type EnumFactory func(string) (interface{}, error)
+
+// NodeParser defines serializer's parse executor
+type NodeParser func(ParseNode) error

--- a/utils.go
+++ b/utils.go
@@ -335,3 +335,15 @@ func CollectionValueCast[R interface{}, T any](items []T) []R {
 	}
 	return cast
 }
+
+// CollectionStructCast casts a collection of values from any type T to given type R
+//
+// Value cast can be used to cast memory addresses to the value of the pointer
+func CollectionStructCast[R interface{}, T any](items []T) []R {
+	cast := make([]R, len(items))
+	for i, v := range items {
+		temp := v
+		cast[i] = any(&temp).(R)
+	}
+	return cast
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,173 @@
+package abstractions
+
+import "github.com/microsoft/kiota-abstractions-go/serialization"
+
+// SetValue receives a source function and applies the results to the setter
+//
+// source is any function that produces (*T, error)
+// setter recipient function of the result of the source if no error is produces
+func SetValue[T interface{}](source func() (*T, error), setter func(t *T)) error {
+	val, err := source()
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		setter(val)
+	}
+	return nil
+}
+
+// SetObjectValue takes a generic source with a discriminator receiver, reads value and writes it to a setter
+//
+// `source func() (*T, error)` is a generic getter with possible error response.
+// `setter func(t *T)` generic function that can write a value from the source
+func SetObjectValue[T interface{}](source func(ctor serialization.ParsableFactory) (serialization.Parsable, error), ctor serialization.ParsableFactory, setter func(t T)) error {
+	val, err := source(ctor)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := (val).(T)
+		setter(res)
+	}
+	return nil
+}
+
+// SetCollectionValue is a utility function that receives a collection that can be cast to Parsable and a function that epects the results
+//
+// source is any function that receives a `ParsableFactory` and returns a slice of Parsable or error
+// ctor is a ParsableFactory
+// setter is a recipient of the function results
+func SetCollectionValue[T interface{}](source func(ctor serialization.ParsableFactory) ([]serialization.Parsable, error), ctor serialization.ParsableFactory, setter func(t []T)) error {
+	val, err := source(ctor)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := make([]T, len(val))
+		for i, v := range val {
+			res[i] = v.(T)
+		}
+		setter(res)
+	}
+	return nil
+}
+
+// CollectionApply applies an operation to every element of the slice and returns a result of the modified collection
+//
+//  is a slice of all the elementents to be mutated
+// mutator applies an operation to the collection and returns a response of type `R`
+func CollectionApply[T any, R interface{}](collection []T, mutator func(t T) R) []R {
+	cast := make([]R, len(collection))
+	for i, v := range collection {
+		cast[i] = mutator(v)
+	}
+	return cast
+}
+
+// SetEnumValue is a utility function that receives an enum getter , EnumFactory and applies the results to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// parser is an EnumFactory
+// setter is a recipient of the function results
+func SetEnumValue[T interface{}](source func(parser serialization.EnumFactory) (interface{}, error), parser serialization.EnumFactory, setter func(t T)) error {
+	val, err := source(parser)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := (val).(T)
+		setter(res)
+	}
+	return nil
+}
+
+// SetReferencedEnumValue is a utility function that receives an enum getter , EnumFactory and applies a de-referenced result of the factory to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// parser is an EnumFactory
+// setter is a recipient of the function results
+func SetReferencedEnumValue[T interface{}](source func(parser serialization.EnumFactory) (interface{}, error), parser serialization.EnumFactory, setter func(t *T)) error {
+	val, err := source(parser)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := (val).(*T)
+		setter(res)
+	}
+	return nil
+}
+
+// SetCollectionOfReferencedEnumValue is a utility function that receives an enum collection source , EnumFactory and applies a de-referenced result of the factory to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// parser is an EnumFactory
+// setter is a recipient of the function results
+func SetCollectionOfReferencedEnumValue[T interface{}](source func(parser serialization.EnumFactory) ([]interface{}, error), parser serialization.EnumFactory, setter func(t []*T)) error {
+	val, err := source(parser)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := make([]*T, len(val))
+		for i, v := range val {
+			res[i] = (v).(*T)
+		}
+		setter(res)
+	}
+	return nil
+}
+
+// SetCollectionOfPrimitiveValue is a utility function that receives a collection of primitives , targetType and applies the result of the factory to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// targetType is a string representing the type of result
+// setter is a recipient of the function results
+func SetCollectionOfPrimitiveValue[T interface{}](source func(targetType string) ([]interface{}, error), targetType string, setter func(t []T)) error {
+	val, err := source(targetType)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := make([]T, len(val))
+		for i, v := range val {
+			res[i] = v.(T)
+		}
+		setter(res)
+	}
+	return nil
+}
+
+// SetCollectionOfReferencedPrimitiveValue is a utility function that receives a collection of primitives , targetType and applies the re-referenced result of the factory to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// parser is an EnumFactory
+// setter is a recipient of the function results
+func SetCollectionOfReferencedPrimitiveValue[T interface{}](source func(targetType string) ([]interface{}, error), targetType string, setter func(t []T)) error {
+	val, err := source(targetType)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := make([]T, len(val))
+		for i, v := range val {
+			res[i] = *(v.(*T))
+		}
+		setter(res)
+	}
+	return nil
+}
+
+func Point[T interface{}](t T) *T {
+	return &t
+}
+
+func GetValueOrDefault[T interface{}](source func() *T, defaultValue T) T {
+	result := source()
+	if result != nil {
+		return *result
+	} else {
+		return defaultValue
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -333,3 +333,19 @@ func SetByteArrayValue(setter func(t []byte)) serialization.NodeParser {
 		return nil
 	}
 }
+
+// CollectionCast casts a collection of values from any type T to given type R
+func CollectionCast[T any, R interface{}](items []T) []R {
+	cast := make([]R, len(items))
+	for i, v := range items {
+		cast[i] = any(v).(R)
+	}
+	return cast
+}
+
+// CollectionCastAsParsable casts a collection of values to a serialization.Parsable of fails
+//
+// Assumes given values implement the serialization.Parsable interface
+func CollectionCastAsParsable[T any](items []T) []serialization.Parsable {
+	return CollectionCast[T, serialization.Parsable](items)
+}

--- a/utils.go
+++ b/utils.go
@@ -335,7 +335,7 @@ func SetByteArrayValue(setter func(t []byte)) serialization.NodeParser {
 }
 
 // CollectionCast casts a collection of values from any type T to given type R
-func CollectionCast[T any, R interface{}](items []T) []R {
+func CollectionCast[R interface{}, T any](items []T) []R {
 	cast := make([]R, len(items))
 	for i, v := range items {
 		cast[i] = any(v).(R)
@@ -343,9 +343,13 @@ func CollectionCast[T any, R interface{}](items []T) []R {
 	return cast
 }
 
-// CollectionCastAsParsable casts a collection of values to a serialization.Parsable of fails
+// CollectionValueCast casts a collection of values from any type T to given type R
 //
-// Assumes given values implement the serialization.Parsable interface
-func CollectionCastAsParsable[T any](items []T) []serialization.Parsable {
-	return CollectionCast[T, serialization.Parsable](items)
+// Value cast can be used to cast memory addresses to the value of the pointer
+func CollectionValueCast[R interface{}, T any](items []T) []R {
+	cast := make([]R, len(items))
+	for i, v := range items {
+		cast[i] = *(any(v).(*R))
+	}
+	return cast
 }

--- a/utils.go
+++ b/utils.go
@@ -94,10 +94,7 @@ func SetCollectionOfReferencedEnumValue[T interface{}](source func(parser serial
 		return err
 	}
 	if val != nil {
-		res := make([]*T, len(val))
-		for i, v := range val {
-			res[i] = (v).(*T)
-		}
+		res := CollectionApply(val, func(v interface{}) *T { return (v).(*T) })
 		setter(res)
 	}
 	return nil
@@ -318,10 +315,7 @@ func SetByteArrayValue(setter func(t []byte)) serialization.NodeParser {
 
 // CollectionCast casts a collection of values from any type T to given type R
 func CollectionCast[R interface{}, T any](items []T) []R {
-	cast := make([]R, len(items))
-	for i, v := range items {
-		cast[i] = any(v).(R)
-	}
+	cast := CollectionApply(items, func(v T) R { return any(v).(R) })
 	return cast
 }
 
@@ -329,10 +323,7 @@ func CollectionCast[R interface{}, T any](items []T) []R {
 //
 // Value cast can be used to cast memory addresses to the value of the pointer
 func CollectionValueCast[R interface{}, T any](items []T) []R {
-	cast := make([]R, len(items))
-	for i, v := range items {
-		cast[i] = *(any(v).(*R))
-	}
+	cast := CollectionApply(items, func(v T) R { return *(any(v).(*R)) })
 	return cast
 }
 
@@ -340,10 +331,9 @@ func CollectionValueCast[R interface{}, T any](items []T) []R {
 //
 // Value cast can be used to cast memory addresses to the value of the pointer
 func CollectionStructCast[R interface{}, T any](items []T) []R {
-	cast := make([]R, len(items))
-	for i, v := range items {
+	cast := CollectionApply(items, func(v T) R {
 		temp := v
-		cast[i] = any(&temp).(R)
-	}
+		return any(&temp).(R)
+	})
 	return cast
 }

--- a/utils.go
+++ b/utils.go
@@ -159,10 +159,12 @@ func SetCollectionOfReferencedPrimitiveValue[T interface{}](source func(targetTy
 	return nil
 }
 
-func Point[T interface{}](t T) *T {
+// P converts a values to a pointer
+func P[T interface{}](t T) *T {
 	return &t
 }
 
+// GetValueOrDefault Converts a Pointer to a value or retuns a default value
 func GetValueOrDefault[T interface{}](source func() *T, defaultValue T) T {
 	result := source()
 	if result != nil {

--- a/utils.go
+++ b/utils.go
@@ -48,10 +48,7 @@ func SetCollectionValue[T interface{}](source func(ctor serialization.ParsableFa
 		return err
 	}
 	if val != nil {
-		res := make([]T, len(val))
-		for i, v := range val {
-			res[i] = v.(T)
-		}
+		res := CollectionCast[T](val)
 		setter(res)
 	}
 	return nil
@@ -117,10 +114,7 @@ func SetCollectionOfPrimitiveValue[T interface{}](source func(targetType string)
 		return err
 	}
 	if val != nil {
-		res := make([]T, len(val))
-		for i, v := range val {
-			res[i] = v.(T)
-		}
+		res := CollectionCast[T](val)
 		setter(res)
 	}
 	return nil
@@ -137,10 +131,7 @@ func SetCollectionOfReferencedPrimitiveValue[T interface{}](source func(targetTy
 		return err
 	}
 	if val != nil {
-		res := make([]T, len(val))
-		for i, v := range val {
-			res[i] = *(v.(*T))
-		}
+		res := CollectionValueCast[T](val)
 		setter(res)
 	}
 	return nil
@@ -169,10 +160,7 @@ func SetCollectionOfObjectValues[T interface{}](ctor serialization.ParsableFacto
 			return err
 		}
 		if val != nil {
-			res := make([]T, len(val))
-			for i, v := range val {
-				res[i] = v.(T)
-			}
+			res := CollectionCast[T](val)
 			setter(res)
 		}
 		return nil
@@ -187,10 +175,7 @@ func SetCollectionOfPrimitiveValues[T interface{}](targetType string, setter fun
 			return err
 		}
 		if val != nil {
-			res := make([]T, len(val))
-			for i, v := range val {
-				res[i] = *(v.(*T))
-			}
+			res := CollectionValueCast[T](val)
 			setter(res)
 		}
 		return nil
@@ -205,10 +190,7 @@ func SetCollectionOfEnumValues[T interface{}](parser serialization.EnumFactory, 
 			return err
 		}
 		if val != nil {
-			res := make([]T, len(val))
-			for i, v := range val {
-				res[i] = *(v.(*T))
-			}
+			res := CollectionValueCast[T](val)
 			setter(res)
 		}
 		return nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -76,6 +76,14 @@ func TestCollectionApply(t *testing.T) {
 	assert.Equal(t, response, []int{1, 2, 3})
 }
 
+func TestCollectionCast1(t *testing.T) {
+	slice := []*int{P(1), P(2), P(3)}
+	response := CollectionValueCast[int](slice)
+
+	assert.Equal(t, len(response), 3)
+	assert.Equal(t, response, []int{1, 2, 3})
+}
+
 func TestCollectionCast(t *testing.T) {
 
 	var val1 interface{}
@@ -86,7 +94,7 @@ func TestCollectionCast(t *testing.T) {
 	val3 = 3
 
 	slice := []interface{}{val1, val2, val3}
-	response := CollectionCast[interface{}, int](slice)
+	response := CollectionCast[int](slice)
 
 	assert.Equal(t, len(response), 3)
 	assert.Equal(t, response, []int{1, 2, 3})
@@ -94,7 +102,7 @@ func TestCollectionCast(t *testing.T) {
 
 func TestCollectionCastAsParsable(t *testing.T) {
 	slice := []interface{}{&internal.CallRecord{}, &internal.CallRecord{}, &internal.CallRecord{}}
-	response := CollectionCastAsParsable(slice)
+	response := CollectionCast[serialization.Parsable](slice)
 
 	assert.Equal(t, len(response), 3)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -76,6 +76,29 @@ func TestCollectionApply(t *testing.T) {
 	assert.Equal(t, response, []int{1, 2, 3})
 }
 
+func TestCollectionCast(t *testing.T) {
+
+	var val1 interface{}
+	val1 = 1
+	var val2 interface{}
+	val2 = 2
+	var val3 interface{}
+	val3 = 3
+
+	slice := []interface{}{val1, val2, val3}
+	response := CollectionCast[interface{}, int](slice)
+
+	assert.Equal(t, len(response), 3)
+	assert.Equal(t, response, []int{1, 2, 3})
+}
+
+func TestCollectionCastAsParsable(t *testing.T) {
+	slice := []interface{}{&internal.CallRecord{}, &internal.CallRecord{}, &internal.CallRecord{}}
+	response := CollectionCastAsParsable(slice)
+
+	assert.Equal(t, len(response), 3)
+}
+
 func getEnumValue(parser serialization.EnumFactory) (interface{}, error) {
 	status := internal.ACTIVE
 	return &status, nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,229 @@
+package abstractions
+
+import (
+	"errors"
+	"github.com/microsoft/kiota-abstractions-go/internal"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"testing"
+)
+
+func TestSetValueWithoutError(t *testing.T) {
+
+	person := internal.NewPerson()
+	callFactory := func() (*internal.CallRecord, error) {
+		return internal.NewCallRecord(), nil
+	}
+
+	err := SetValue(callFactory, person.SetCallRecord)
+	assert.Nil(t, err)
+	assert.NotNil(t, person.GetCallRecord())
+}
+
+func TestSetValueWithError(t *testing.T) {
+
+	person := internal.NewPerson()
+	callFactory := func() (*internal.CallRecord, error) {
+		return nil, errors.New("could not get from factory")
+	}
+
+	err := SetValue(callFactory, person.SetCallRecord)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetCallRecord())
+}
+
+func createCallRecordNode(parseNode serialization.ParseNode) (serialization.Parsable, error) {
+	return internal.NewCallRecord(), nil
+}
+
+func getObjectValue(ctor serialization.ParsableFactory) (serialization.Parsable, error) {
+	return internal.NewCallRecord(), nil
+}
+
+func getObjectValueWithError(ctor serialization.ParsableFactory) (serialization.Parsable, error) {
+	return nil, errors.New("could not get from factory")
+}
+
+func TestSetObjectValueWithoutError(t *testing.T) {
+
+	person := internal.NewPerson()
+	err := SetObjectValue(getObjectValue, createCallRecordNode, person.SetCallRecord)
+	assert.Nil(t, err)
+	assert.NotNil(t, person.GetCallRecord())
+}
+
+func TestSetObjectValueWithError(t *testing.T) {
+
+	person := internal.NewPerson()
+	err := SetObjectValue(getObjectValueWithError, createCallRecordNode, person.SetCallRecord)
+
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetCallRecord())
+}
+
+func getObjectsValues(ctor serialization.ParsableFactory) ([]serialization.Parsable, error) {
+	slice := []serialization.Parsable{internal.NewCallRecord(), internal.NewCallRecord(), internal.NewCallRecord()}
+	return slice, nil
+}
+
+func getObjectsValuesWithError(ctor serialization.ParsableFactory) ([]serialization.Parsable, error) {
+	return nil, errors.New("could not get from factory")
+}
+
+func TestSetCollectionValueValueWithoutError(t *testing.T) {
+
+	person := internal.NewPerson()
+	err := SetCollectionValue(getObjectsValues, createCallRecordNode, person.SetCallRecords)
+	assert.Nil(t, err)
+	assert.NotNil(t, person.GetCallRecords())
+	assert.Equal(t, len(person.GetCallRecords()), 3)
+}
+
+func TestSetCollectionValueValueWithError(t *testing.T) {
+
+	person := internal.NewPerson()
+	err := SetCollectionValue(getObjectsValuesWithError, createCallRecordNode, person.SetCallRecords)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetCallRecords())
+	assert.Equal(t, len(person.GetCallRecords()), 0)
+}
+
+func TestCollectionApply(t *testing.T) {
+
+	slice := []string{"1", "2", "3"}
+	response := CollectionApply(slice, func(s string) int {
+		i, _ := strconv.Atoi(s)
+		return i
+	})
+
+	assert.Equal(t, len(response), 3)
+	assert.Equal(t, response, []int{1, 2, 3})
+}
+
+func getEnumValue(parser serialization.EnumFactory) (interface{}, error) {
+	status := internal.ACTIVE
+	return &status, nil
+}
+
+func TestSetEnumValueValueValueWithoutError(t *testing.T) {
+	person := internal.NewPerson()
+	err := SetEnumValue(getEnumValue, internal.ParsePersonStatus, person.SetStatus)
+	assert.Nil(t, err)
+	assert.Equal(t, person.GetStatus().String(), internal.ACTIVE.String())
+}
+
+func getEnumValueWithError(parser serialization.EnumFactory) (interface{}, error) {
+	return nil, errors.New("could not get from factory")
+}
+
+func TestSetEnumValueValueValueWithError(t *testing.T) {
+	person := internal.NewPerson()
+	err := SetEnumValue(getEnumValueWithError, internal.ParsePersonStatus, person.SetStatus)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetStatus())
+}
+
+func TestSetReferencedEnumValueValueValueWithoutError(t *testing.T) {
+	person := internal.NewPerson()
+	err := SetReferencedEnumValue(getEnumValue, internal.ParsePersonStatus, person.SetStatus)
+	assert.Nil(t, err)
+	assert.Equal(t, person.GetStatus().String(), internal.ACTIVE.String())
+}
+
+func TestSetReferencedEnumValueValueValueWithError(t *testing.T) {
+	person := internal.NewPerson()
+	err := SetReferencedEnumValue(getEnumValueWithError, internal.ParsePersonStatus, person.SetStatus)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetStatus())
+}
+
+func TestSetCollectionOfReferencedEnumValueWithoutError(t *testing.T) {
+	person := internal.NewPerson()
+
+	slice := []interface{}{Point(internal.ACTIVE), Point(internal.SUSPEND)}
+	enumSource := func(parser serialization.EnumFactory) ([]interface{}, error) {
+		return slice, nil
+	}
+
+	err := SetCollectionOfReferencedEnumValue(enumSource, internal.ParsePersonStatus, person.SetPreviousStatus)
+	assert.Nil(t, err)
+	assert.Equal(t, person.GetPreviousStatus()[0].String(), internal.ACTIVE.String())
+	assert.Equal(t, person.GetPreviousStatus()[1].String(), internal.SUSPEND.String())
+}
+
+func TestSetCollectionOfReferencedEnumValueWithError(t *testing.T) {
+	person := internal.NewPerson()
+
+	enumSource := func(parser serialization.EnumFactory) ([]interface{}, error) {
+		return nil, errors.New("could not get from factory")
+	}
+
+	err := SetCollectionOfReferencedEnumValue(enumSource, internal.ParsePersonStatus, person.SetPreviousStatus)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetPreviousStatus())
+}
+
+func TestSetCollectionOfReferencedPrimitiveValueWithoutError(t *testing.T) {
+	person := internal.NewPerson()
+
+	slice := []interface{}{Point(1), Point(2), Point(3)}
+	dataSource := func(targetType string) ([]interface{}, error) {
+		return slice, nil
+	}
+
+	err := SetCollectionOfReferencedPrimitiveValue(dataSource, "int", person.SetCardNumbers)
+	assert.Nil(t, err)
+	assert.Equal(t, person.GetCardNumbers()[0], 1)
+	assert.Equal(t, person.GetCardNumbers()[1], 2)
+	assert.Equal(t, person.GetCardNumbers()[2], 3)
+}
+
+func TestSetCollectionOfReferencedPrimitiveValueWithError(t *testing.T) {
+	person := internal.NewPerson()
+
+	dataSource := func(targetType string) ([]interface{}, error) {
+		return nil, errors.New("could not get from factory")
+	}
+
+	err := SetCollectionOfReferencedPrimitiveValue(dataSource, "int", person.SetCardNumbers)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetCardNumbers())
+}
+
+func TestSetCollectionOfPrimitiveValueWithoutError(t *testing.T) {
+	person := internal.NewPerson()
+
+	slice := []interface{}{1, 2, 3}
+	dataSource := func(targetType string) ([]interface{}, error) {
+		return slice, nil
+	}
+
+	err := SetCollectionOfPrimitiveValue(dataSource, "int", person.SetCardNumbers)
+	assert.Nil(t, err)
+	assert.Equal(t, person.GetCardNumbers()[0], 1)
+	assert.Equal(t, person.GetCardNumbers()[1], 2)
+	assert.Equal(t, person.GetCardNumbers()[1], 2)
+	assert.Equal(t, person.GetCardNumbers()[2], 3)
+}
+
+func TestSetCollectionOfPrimitiveValueWithError(t *testing.T) {
+	person := internal.NewPerson()
+
+	dataSource := func(targetType string) ([]interface{}, error) {
+		return nil, errors.New("could not get from factory")
+	}
+
+	err := SetCollectionOfPrimitiveValue(dataSource, "int", person.SetCardNumbers)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetCardNumbers())
+}
+
+func TestGetValueReturn(t *testing.T) {
+	person := internal.NewPerson()
+
+	assert.Equal(t, GetValueOrDefault(person.GetDisplayName, "Unknown"), "Unknown")
+
+	person.SetDisplayName(Point("Jane"))
+	assert.Equal(t, GetValueOrDefault(person.GetDisplayName, "Unknown"), "Jane")
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -219,3 +219,30 @@ func TestGetValueReturn(t *testing.T) {
 	person.SetDisplayName(P("Jane"))
 	assert.Equal(t, GetValueOrDefault(person.GetDisplayName, "Unknown"), "Jane")
 }
+
+type foo struct {
+	Name string
+}
+
+type animal interface {
+	Eat()
+	Call() string
+}
+
+type dog interface {
+	Bark()
+	Call() string
+}
+
+func (f *foo) Bark()        {}
+func (f *foo) Eat()         {}
+func (f *foo) Call() string { return f.Name }
+
+func TestCollectionStructCast(t *testing.T) {
+
+	foos := []foo{{Name: "Cooper"}, {Name: "Buddy"}, {Name: "Peanut"}}
+	animals := CollectionStructCast[animal](foos)
+	assert.Equal(t, "Cooper", animals[0].Call())
+	assert.Equal(t, "Buddy", animals[1].Call())
+	assert.Equal(t, "Peanut", animals[2].Call())
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -141,7 +141,7 @@ func TestSetReferencedEnumValueValueValueWithError(t *testing.T) {
 func TestSetCollectionOfReferencedEnumValueWithoutError(t *testing.T) {
 	person := internal.NewPerson()
 
-	slice := []interface{}{Point(internal.ACTIVE), Point(internal.SUSPEND)}
+	slice := []interface{}{P(internal.ACTIVE), P(internal.SUSPEND)}
 	enumSource := func(parser serialization.EnumFactory) ([]interface{}, error) {
 		return slice, nil
 	}
@@ -167,7 +167,7 @@ func TestSetCollectionOfReferencedEnumValueWithError(t *testing.T) {
 func TestSetCollectionOfReferencedPrimitiveValueWithoutError(t *testing.T) {
 	person := internal.NewPerson()
 
-	slice := []interface{}{Point(1), Point(2), Point(3)}
+	slice := []interface{}{P(1), P(2), P(3)}
 	dataSource := func(targetType string) ([]interface{}, error) {
 		return slice, nil
 	}
@@ -224,6 +224,6 @@ func TestGetValueReturn(t *testing.T) {
 
 	assert.Equal(t, GetValueOrDefault(person.GetDisplayName, "Unknown"), "Unknown")
 
-	person.SetDisplayName(Point("Jane"))
+	person.SetDisplayName(P("Jane"))
 	assert.Equal(t, GetValueOrDefault(person.GetDisplayName, "Unknown"), "Jane")
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -37,31 +37,6 @@ func createCallRecordNode(parseNode serialization.ParseNode) (serialization.Pars
 	return internal.NewCallRecord(), nil
 }
 
-func getObjectValue(ctor serialization.ParsableFactory) (serialization.Parsable, error) {
-	return internal.NewCallRecord(), nil
-}
-
-func getObjectValueWithError(ctor serialization.ParsableFactory) (serialization.Parsable, error) {
-	return nil, errors.New("could not get from factory")
-}
-
-func TestSetObjectValueWithoutError(t *testing.T) {
-
-	person := internal.NewPerson()
-	err := SetObjectValue(getObjectValue, createCallRecordNode, person.SetCallRecord)
-	assert.Nil(t, err)
-	assert.NotNil(t, person.GetCallRecord())
-}
-
-func TestSetObjectValueWithError(t *testing.T) {
-
-	person := internal.NewPerson()
-	err := SetObjectValue(getObjectValueWithError, createCallRecordNode, person.SetCallRecord)
-
-	assert.NotNil(t, err)
-	assert.Nil(t, person.GetCallRecord())
-}
-
 func getObjectsValues(ctor serialization.ParsableFactory) ([]serialization.Parsable, error) {
 	slice := []serialization.Parsable{internal.NewCallRecord(), internal.NewCallRecord(), internal.NewCallRecord()}
 	return slice, nil
@@ -106,22 +81,8 @@ func getEnumValue(parser serialization.EnumFactory) (interface{}, error) {
 	return &status, nil
 }
 
-func TestSetEnumValueValueValueWithoutError(t *testing.T) {
-	person := internal.NewPerson()
-	err := SetEnumValue(getEnumValue, internal.ParsePersonStatus, person.SetStatus)
-	assert.Nil(t, err)
-	assert.Equal(t, person.GetStatus().String(), internal.ACTIVE.String())
-}
-
 func getEnumValueWithError(parser serialization.EnumFactory) (interface{}, error) {
 	return nil, errors.New("could not get from factory")
-}
-
-func TestSetEnumValueValueValueWithError(t *testing.T) {
-	person := internal.NewPerson()
-	err := SetEnumValue(getEnumValueWithError, internal.ParsePersonStatus, person.SetStatus)
-	assert.NotNil(t, err)
-	assert.Nil(t, person.GetStatus())
 }
 
 func TestSetReferencedEnumValueValueValueWithoutError(t *testing.T) {


### PR DESCRIPTION
## Overview

Partially address https://github.com/microsoft/kiota/issues/1404

Adds generic helper methods for serializers and deserializers

## Demo

SetValue 
Current 

```go
    res["proof"] = func (n i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error {
        val, err := n.GetStringValue()
        if err != nil {
            return err
        }
        if val != nil {
            m.SetProof(val)
        }
        return nil
    }
```
Is transformed to 
```go
	res["proof"] = msgraphsdkgo.SetStringValue(m.SetProof)
}
```

SetObjectValue

Current 
```go
    res["passwordCredential"] = func (n serialization.ParseNode) error {
        val, err := n.GetObjectValue(iadcd81124412c61e647227ecfc4449d8bba17de0380ddda76f641a29edf2b242.CreatePasswordCredentialFromDiscriminatorValue)
        if err != nil {
            return err
        }
        if val != nil {
            m.SetPasswordCredential(val.(iadcd81124412c61e647227ecfc4449d8bba17de0380ddda76f641a29edf2b242.PasswordCredentialable))
        }
        return nil
    }
```

Final
```go
	res["passwordCredential"] =  msgraphsdkgo.SetObjectValue(n.GetObjectValue, iadcd81124412c61e647227ecfc4449d8bba17de0380ddda76f641a29edf2b242.CreatePasswordCredentialFromDiscriminatorValue, m.SetPasswordCredential)
```

SetCollectionValue
From
```go
	res["value"] = func(n serialization.ParseNode) error {
		val, err := n.GetCollectionOfObjectValues(CreatePinnedChatMessageInfoFromDiscriminatorValue)
		if err != nil {
			return err
		}
		if val != nil {
			res := make([]PinnedChatMessageInfoable, len(val))
			for i, v := range val {
				res[i] = v.(PinnedChatMessageInfoable)
			}
			m.SetValue(res)
		}
		return nil
	}
```

To
```go
	res["value"] = msgraphsdkgo.SetCollectionValue[PinnedChatMessageInfoable](n.GetCollectionOfObjectValues, CreatePinnedChatMessageInfoFromDiscriminatorValue, m.SetValue)
```

Collection Apply

From
```go
        cast := make([]i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable, len(m.GetValue()))
        for i, v := range m.GetValue() {
            cast[i] = v.(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable)
        }
```

To
```go
		cast := msgraphsdkgo.CollectionApply(m.GetValue(), func(v PinnedChatMessageInfoable) i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable {
			return v.(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable)
		})
```