### PR TITLE
Fix/add serialize unknown types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.11.0] - 2022-09-22
+
+### Add
+
+- Adds `WriteAnyValues` to support serialization of objects with undetermined properties at execution time e.g maps.
+- Adds `GetRawValue` to allow returning an `interface{}` from the parse-node
+
 ## [0.10.1] - 2022-09-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Add
 - Adds generic helper methods to reduce code duplication for serializer and deserializers
-- Adds `WriteAnyValues` to support serialization of objects with undetermined properties at execution time e.g maps.
+- Adds `WriteAnyValue` to support serialization of objects with undetermined properties at execution time e.g maps.
 - Adds `GetRawValue` to allow returning an `interface{}` from the parse-node
 
 ## [0.10.1] - 2022-09-14

--- a/api_client_builder_test.go
+++ b/api_client_builder_test.go
@@ -1,127 +1,15 @@
 package abstractions
 
 import (
-	"testing"
-	"time"
-
-	"github.com/google/uuid"
+	"github.com/microsoft/kiota-abstractions-go/internal"
 	serialization "github.com/microsoft/kiota-abstractions-go/serialization"
 	assert "github.com/stretchr/testify/assert"
+	"testing"
 )
-
-type mockSerializer struct {
-}
-
-func (*mockSerializer) WriteStringValue(key string, value *string) error {
-	return nil
-}
-func (*mockSerializer) WriteBoolValue(key string, value *bool) error {
-	return nil
-}
-func (*mockSerializer) WriteByteValue(key string, value *byte) error {
-	return nil
-}
-func (*mockSerializer) WriteInt8Value(key string, value *int8) error {
-	return nil
-}
-func (*mockSerializer) WriteInt32Value(key string, value *int32) error {
-	return nil
-}
-func (*mockSerializer) WriteInt64Value(key string, value *int64) error {
-	return nil
-}
-func (*mockSerializer) WriteFloat32Value(key string, value *float32) error {
-	return nil
-}
-func (*mockSerializer) WriteFloat64Value(key string, value *float64) error {
-	return nil
-}
-func (*mockSerializer) WriteByteArrayValue(key string, value []byte) error {
-	return nil
-}
-func (*mockSerializer) WriteTimeValue(key string, value *time.Time) error {
-	return nil
-}
-func (*mockSerializer) WriteISODurationValue(key string, value *serialization.ISODuration) error {
-	return nil
-}
-func (*mockSerializer) WriteDateOnlyValue(key string, value *serialization.DateOnly) error {
-	return nil
-}
-func (*mockSerializer) WriteTimeOnlyValue(key string, value *serialization.TimeOnly) error {
-	return nil
-}
-func (*mockSerializer) WriteUUIDValue(key string, value *uuid.UUID) error {
-	return nil
-}
-func (*mockSerializer) WriteObjectValue(key string, item serialization.Parsable, additionalValuesToMerge ...serialization.Parsable) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfObjectValues(key string, collection []serialization.Parsable) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfStringValues(key string, collection []string) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfBoolValues(key string, collection []bool) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfByteValues(key string, collection []byte) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfInt8Values(key string, collection []int8) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfInt32Values(key string, collection []int32) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfInt64Values(key string, collection []int64) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfFloat32Values(key string, collection []float32) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfFloat64Values(key string, collection []float64) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfTimeValues(key string, collection []time.Time) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfISODurationValues(key string, collection []serialization.ISODuration) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfDateOnlyValues(key string, collection []serialization.DateOnly) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfTimeOnlyValues(key string, collection []serialization.TimeOnly) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfUUIDValues(key string, collection []uuid.UUID) error {
-	return nil
-}
-func (*mockSerializer) GetSerializedContent() ([]byte, error) {
-	return nil, nil
-}
-func (*mockSerializer) WriteAdditionalData(value map[string]interface{}) error {
-	return nil
-}
-func (*mockSerializer) Close() error {
-	return nil
-}
-
-type mockSerializerFactory struct {
-}
-
-func (*mockSerializerFactory) GetValidContentType() (string, error) {
-	return "application/json", nil
-}
-func (*mockSerializerFactory) GetSerializationWriter(contentType string) (serialization.SerializationWriter, error) {
-	return &mockSerializer{}, nil
-}
 
 func TestItCreatesClientConcurrently(t *testing.T) {
 	metaFactory := func() serialization.SerializationWriterFactory {
-		return &mockSerializerFactory{}
+		return &internal.MockSerializerFactory{}
 	}
 	for i := 0; i < 1000; i++ {
 		go RegisterDefaultSerializer(metaFactory)

--- a/internal/mock_serializer.go
+++ b/internal/mock_serializer.go
@@ -102,7 +102,7 @@ func (*MockSerializer) GetSerializedContent() ([]byte, error) {
 func (*MockSerializer) WriteAdditionalData(value map[string]interface{}) error {
 	return nil
 }
-func (*MockSerializer) WriteAnyValues(key string, value interface{}) error {
+func (*MockSerializer) WriteAnyValue(key string, value interface{}) error {
 	return nil
 }
 func (*MockSerializer) Close() error {

--- a/internal/mock_serializer.go
+++ b/internal/mock_serializer.go
@@ -1,0 +1,120 @@
+package internal
+
+import (
+	"github.com/google/uuid"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
+	"time"
+)
+
+type MockSerializer struct {
+}
+
+func (*MockSerializer) WriteStringValue(key string, value *string) error {
+	return nil
+}
+func (*MockSerializer) WriteBoolValue(key string, value *bool) error {
+	return nil
+}
+func (*MockSerializer) WriteByteValue(key string, value *byte) error {
+	return nil
+}
+func (*MockSerializer) WriteInt8Value(key string, value *int8) error {
+	return nil
+}
+func (*MockSerializer) WriteInt32Value(key string, value *int32) error {
+	return nil
+}
+func (*MockSerializer) WriteInt64Value(key string, value *int64) error {
+	return nil
+}
+func (*MockSerializer) WriteFloat32Value(key string, value *float32) error {
+	return nil
+}
+func (*MockSerializer) WriteFloat64Value(key string, value *float64) error {
+	return nil
+}
+func (*MockSerializer) WriteByteArrayValue(key string, value []byte) error {
+	return nil
+}
+func (*MockSerializer) WriteTimeValue(key string, value *time.Time) error {
+	return nil
+}
+func (*MockSerializer) WriteISODurationValue(key string, value *serialization.ISODuration) error {
+	return nil
+}
+func (*MockSerializer) WriteDateOnlyValue(key string, value *serialization.DateOnly) error {
+	return nil
+}
+func (*MockSerializer) WriteTimeOnlyValue(key string, value *serialization.TimeOnly) error {
+	return nil
+}
+func (*MockSerializer) WriteUUIDValue(key string, value *uuid.UUID) error {
+	return nil
+}
+func (*MockSerializer) WriteObjectValue(key string, item serialization.Parsable, additionalValuesToMerge ...serialization.Parsable) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfObjectValues(key string, collection []serialization.Parsable) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfStringValues(key string, collection []string) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfBoolValues(key string, collection []bool) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfByteValues(key string, collection []byte) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfInt8Values(key string, collection []int8) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfInt32Values(key string, collection []int32) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfInt64Values(key string, collection []int64) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfFloat32Values(key string, collection []float32) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfFloat64Values(key string, collection []float64) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfTimeValues(key string, collection []time.Time) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfISODurationValues(key string, collection []serialization.ISODuration) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfDateOnlyValues(key string, collection []serialization.DateOnly) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfTimeOnlyValues(key string, collection []serialization.TimeOnly) error {
+	return nil
+}
+func (*MockSerializer) WriteCollectionOfUUIDValues(key string, collection []uuid.UUID) error {
+	return nil
+}
+func (*MockSerializer) GetSerializedContent() ([]byte, error) {
+	return nil, nil
+}
+func (*MockSerializer) WriteAdditionalData(value map[string]interface{}) error {
+	return nil
+}
+func (*MockSerializer) WriteAnyValues(key string, value interface{}) error {
+	return nil
+}
+func (*MockSerializer) Close() error {
+	return nil
+}
+
+type MockSerializerFactory struct {
+}
+
+func (*MockSerializerFactory) GetValidContentType() (string, error) {
+	return "application/json", nil
+}
+func (*MockSerializerFactory) GetSerializationWriter(contentType string) (serialization.SerializationWriter, error) {
+	return &MockSerializer{}, nil
+}

--- a/serialization/parse_node.go
+++ b/serialization/parse_node.go
@@ -48,4 +48,6 @@ type ParseNode interface {
 	GetEnumValue(parser EnumFactory) (interface{}, error)
 	// GetByteArrayValue returns a ByteArray value from the nodes.
 	GetByteArrayValue() ([]byte, error)
+	// GetRawValue returns the values of the node as an interface of any type.
+	GetRawValue() (interface{}, error)
 }

--- a/serialization/serialization_writer.go
+++ b/serialization/serialization_writer.go
@@ -72,6 +72,6 @@ type SerializationWriter interface {
 	GetSerializedContent() ([]byte, error)
 	// WriteAdditionalData writes additional data to underlying the byte array.
 	WriteAdditionalData(value map[string]interface{}) error
-	// WriteAnyValues an object of unknown type as a json value
-	WriteAnyValues(key string, value interface{}) error
+	// WriteAnyValue an object of unknown type as a json value
+	WriteAnyValue(key string, value interface{}) error
 }

--- a/serialization/serialization_writer.go
+++ b/serialization/serialization_writer.go
@@ -72,4 +72,6 @@ type SerializationWriter interface {
 	GetSerializedContent() ([]byte, error)
 	// WriteAdditionalData writes additional data to underlying the byte array.
 	WriteAdditionalData(value map[string]interface{}) error
+	// WriteAnyValues an object of unknown type as a json value
+	WriteAnyValues(key string, value interface{}) error
 }

--- a/serialization/serialization_writer_factory_registry_test.go
+++ b/serialization/serialization_writer_factory_registry_test.go
@@ -1,126 +1,13 @@
 package serialization
 
 import (
-	"testing"
-	"time"
-
-	"github.com/google/uuid"
-
+	"github.com/microsoft/kiota-abstractions-go/internal"
 	assert "github.com/stretchr/testify/assert"
+	"testing"
 )
 
-type mockSerializer struct {
-}
-
-func (*mockSerializer) WriteStringValue(key string, value *string) error {
-	return nil
-}
-func (*mockSerializer) WriteBoolValue(key string, value *bool) error {
-	return nil
-}
-func (*mockSerializer) WriteByteValue(key string, value *byte) error {
-	return nil
-}
-func (*mockSerializer) WriteInt8Value(key string, value *int8) error {
-	return nil
-}
-func (*mockSerializer) WriteInt32Value(key string, value *int32) error {
-	return nil
-}
-func (*mockSerializer) WriteInt64Value(key string, value *int64) error {
-	return nil
-}
-func (*mockSerializer) WriteFloat32Value(key string, value *float32) error {
-	return nil
-}
-func (*mockSerializer) WriteFloat64Value(key string, value *float64) error {
-	return nil
-}
-func (*mockSerializer) WriteByteArrayValue(key string, value []byte) error {
-	return nil
-}
-func (*mockSerializer) WriteTimeValue(key string, value *time.Time) error {
-	return nil
-}
-func (*mockSerializer) WriteISODurationValue(key string, value *ISODuration) error {
-	return nil
-}
-func (*mockSerializer) WriteDateOnlyValue(key string, value *DateOnly) error {
-	return nil
-}
-func (*mockSerializer) WriteTimeOnlyValue(key string, value *TimeOnly) error {
-	return nil
-}
-func (*mockSerializer) WriteUUIDValue(key string, value *uuid.UUID) error {
-	return nil
-}
-func (*mockSerializer) WriteObjectValue(key string, item Parsable, additionalValuesToMerge ...Parsable) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfObjectValues(key string, collection []Parsable) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfStringValues(key string, collection []string) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfBoolValues(key string, collection []bool) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfByteValues(key string, collection []byte) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfInt8Values(key string, collection []int8) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfInt32Values(key string, collection []int32) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfInt64Values(key string, collection []int64) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfFloat32Values(key string, collection []float32) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfFloat64Values(key string, collection []float64) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfTimeValues(key string, collection []time.Time) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfISODurationValues(key string, collection []ISODuration) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfDateOnlyValues(key string, collection []DateOnly) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfTimeOnlyValues(key string, collection []TimeOnly) error {
-	return nil
-}
-func (*mockSerializer) WriteCollectionOfUUIDValues(key string, collection []uuid.UUID) error {
-	return nil
-}
-func (*mockSerializer) GetSerializedContent() ([]byte, error) {
-	return nil, nil
-}
-func (*mockSerializer) WriteAdditionalData(value map[string]interface{}) error {
-	return nil
-}
-func (*mockSerializer) Close() error {
-	return nil
-}
-
-type mockSerializerFactory struct {
-}
-
-func (*mockSerializerFactory) GetValidContentType() (string, error) {
-	return "application/json", nil
-}
-func (*mockSerializerFactory) GetSerializationWriter(contentType string) (SerializationWriter, error) {
-	return &mockSerializer{}, nil
-}
-
 func TestItGetsVendorSpecificSerializationWriter(t *testing.T) {
-	DefaultSerializationWriterFactoryInstance.ContentTypeAssociatedFactories["application/json"] = &mockSerializerFactory{}
+	DefaultSerializationWriterFactoryInstance.ContentTypeAssociatedFactories["application/json"] = &internal.MockSerializerFactory{}
 	serializationWriter, err := DefaultSerializationWriterFactoryInstance.GetSerializationWriter("application/vnd+json")
 	assert.Nil(t, err)
 	assert.NotNil(t, serializationWriter)

--- a/utils.go
+++ b/utils.go
@@ -134,8 +134,7 @@ func SetCollectionOfReferencedPrimitiveValue[T interface{}](source func(targetTy
 	return nil
 }
 
-// P converts a values to a pointer
-func P[T interface{}](t T) *T {
+func p[T interface{}](t T) *T {
 	return &t
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -77,7 +77,7 @@ func TestCollectionApply(t *testing.T) {
 }
 
 func TestCollectionCast1(t *testing.T) {
-	slice := []*int{P(1), P(2), P(3)}
+	slice := []*int{p(1), p(2), p(3)}
 	response := CollectionValueCast[int](slice)
 
 	assert.Equal(t, len(response), 3)
@@ -133,7 +133,7 @@ func TestSetReferencedEnumValueValueValueWithError(t *testing.T) {
 func TestSetCollectionOfReferencedEnumValueWithoutError(t *testing.T) {
 	person := internal.NewPerson()
 
-	slice := []interface{}{P(internal.ACTIVE), P(internal.SUSPEND)}
+	slice := []interface{}{p(internal.ACTIVE), p(internal.SUSPEND)}
 	enumSource := func(parser serialization.EnumFactory) ([]interface{}, error) {
 		return slice, nil
 	}
@@ -159,7 +159,7 @@ func TestSetCollectionOfReferencedEnumValueWithError(t *testing.T) {
 func TestSetCollectionOfReferencedPrimitiveValueWithoutError(t *testing.T) {
 	person := internal.NewPerson()
 
-	slice := []interface{}{P(1), P(2), P(3)}
+	slice := []interface{}{p(1), p(2), p(3)}
 	dataSource := func(targetType string) ([]interface{}, error) {
 		return slice, nil
 	}
@@ -216,7 +216,7 @@ func TestGetValueReturn(t *testing.T) {
 
 	assert.Equal(t, GetValueOrDefault(person.GetDisplayName, "Unknown"), "Unknown")
 
-	person.SetDisplayName(P("Jane"))
+	person.SetDisplayName(p("Jane"))
 	assert.Equal(t, GetValueOrDefault(person.GetDisplayName, "Unknown"), "Jane")
 }
 


### PR DESCRIPTION
Adds `WriteAnyValues` and `GetRawValue` that should be implemented by serialization libraries.

These methods should support attempting to serialize properties that don't have explicit types known ahead of execution time e.g serialization of maps.

Example Use Case
[Batch Requests ](https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/11)
Gracefully handling some cases when docs are out of sync as reported [here ](https://github.com/microsoftgraph/msgraph-sdk-go/issues/258)