### PR TITLE
Fix bug where empty string query parameters are added to the request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.15.2] - 2023-01-09
+
+### Changed
+
+- Fix bug where empty string query parameters are added to the request.
+
 ## [0.15.1] - 2022-12-15
 
 ### Changed

--- a/request_information.go
+++ b/request_information.go
@@ -463,7 +463,7 @@ func (request *RequestInformation) AddQueryParameters(source interface{}) {
 			continue
 		}
 		str, ok := value.(*string)
-		if ok && str != nil {
+		if ok && str != nil && *str != "" {
 			request.QueryParameters[fieldName] = *str
 		}
 		bl, ok := value.(*bool)

--- a/request_information_test.go
+++ b/request_information_test.go
@@ -97,6 +97,29 @@ func TestItSetsSelectAndCountQueryParameters(t *testing.T) {
 	assert.Equal(t, "http://localhost/me?%24select=id%2CdisplayName&%24count=true", resultUri.String())
 }
 
+func TestItDoesNotSetEmptySelectQueryParameters(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/me{?%24select}"
+	requestInformation.AddQueryParameters(getQueryParameters{
+		Select_escaped: []string{},
+	})
+	resultUri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost/me", resultUri.String())
+}
+
+func TestItDoesNotSetEmptySearchQueryParameters(t *testing.T) {
+	emptyString := ""
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/me{?%24search}"
+	requestInformation.AddQueryParameters(getQueryParameters{
+		Search: &emptyString,
+	})
+	resultUri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost/me", resultUri.String())
+}
+
 func TestItSetsPathParametersOfDateTimeOffsetType(t *testing.T) {
 	requestInformation := NewRequestInformation()
 	requestInformation.UrlTemplate = "http://localhost/getDirectRoutingCalls(fromDateTime='{fromDateTime}',toDateTime='{toDateTime}')"


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota-abstractions-dotnet/issues/60

In summary,

- Fix bug where empty string query parameters are added to the request.
- Adds test to validate collection scenario which works well