### PR TITLE
Adds a copy map util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.18.0] - 2023-03-20
+
+### Added
+
+- Adds utility functions `CopyMap` and `CopyStringMap` that returns a copy of the passed map.
+
 ## [0.17.3] - 2023-03-15
 
 ### Changed

--- a/utils.go
+++ b/utils.go
@@ -351,3 +351,21 @@ func InvokeParsableWriter(writer serialization.ParsableWriter, parsable serializ
 	}
 	return nil
 }
+
+// CopyMap returns a copy of map[string]string
+func CopyMap[T comparable, R interface{}](items map[T]R) map[T]R {
+	result := make(map[T]R)
+	for idx, item := range items {
+		result[idx] = item
+	}
+	return result
+}
+
+// CopyStringMap returns a copy of map[string]string
+func CopyStringMap(items map[string]string) map[string]string {
+	result := make(map[string]string)
+	for idx, item := range items {
+		result[idx] = item
+	}
+	return result
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -246,3 +246,17 @@ func TestCollectionStructCast(t *testing.T) {
 	assert.Equal(t, "Buddy", animals[1].Call())
 	assert.Equal(t, "Peanut", animals[2].Call())
 }
+
+func TestCopyMap(t *testing.T) {
+	source := map[string]int{"foo": 1, "bar": 2}
+	duplicate := CopyMap(source)
+
+	assert.Equal(t, duplicate, source)
+}
+
+func TestStringCopyMap(t *testing.T) {
+	source := map[string]string{"foo": "1", "bar": "2"}
+	duplicate := CopyStringMap(source)
+
+	assert.Equal(t, duplicate, source)
+}


### PR DESCRIPTION
Resolves https://github.com/microsoft/kiota/issues/2421

Adds  utility functions to copy a map and its values. 
`CopyMap`  is a generic implementation which support any comparable key to a type.  (should still cause a performance issue when used extensively)
`CopyStringMap` duplicates a string map 