### PR TITLE
Fix concurrent map write panics in api_client_builder.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.19.1] - 2023-04-12
+
+### Added
+
+### Changed
+
+- Fixes concurrent map write panics when enabling backing stores.
+
 ## [0.19.0] - 2023-03-22
 
 ### Added

--- a/api_client_builder.go
+++ b/api_client_builder.go
@@ -42,11 +42,11 @@ func EnableBackingStoreForSerializationWriterFactory(factory s.SerializationWrit
 }
 
 func enableBackingStoreForSerializationRegistry(registry *s.SerializationWriterFactoryRegistry) {
+	registry.Lock()
+	defer registry.Unlock()
 	for key, value := range registry.ContentTypeAssociatedFactories {
 		if _, ok := value.(*store.BackingStoreSerializationWriterProxyFactory); !ok {
-			registry.Lock()
 			registry.ContentTypeAssociatedFactories[key] = store.NewBackingStoreSerializationWriterProxyFactory(value)
-			registry.Unlock()
 		}
 	}
 }
@@ -64,11 +64,11 @@ func EnableBackingStoreForParseNodeFactory(factory s.ParseNodeFactory) s.ParseNo
 }
 
 func enableBackingStoreForParseNodeRegistry(registry *s.ParseNodeFactoryRegistry) {
+	registry.Lock()
+	defer registry.Unlock()
 	for key, value := range registry.ContentTypeAssociatedFactories {
 		if _, ok := value.(*store.BackingStoreParseNodeFactory); !ok {
-			registry.Lock()
 			registry.ContentTypeAssociatedFactories[key] = store.NewBackingStoreParseNodeFactory(value)
-			registry.Unlock()
 		}
 	}
 }

--- a/api_client_builder.go
+++ b/api_client_builder.go
@@ -7,7 +7,12 @@ import (
 	s "github.com/microsoft/kiota-abstractions-go/serialization"
 )
 
+// serializerMutex is used when accessing fields of serialization.SerializationWriterFactory
+// objects to ensure that they are not written to concurrently.
 var serializerMutex sync.Mutex
+
+// deserializerMutex is used when accessing fields of serialization.ParseNodeFactory
+// objects to ensure that they are not written to concurrently.
 var deserializerMutex sync.Mutex
 
 // RegisterDefaultSerializer registers the default serializer to the registry singleton to be used by the request adapter.

--- a/api_client_builder.go
+++ b/api_client_builder.go
@@ -23,9 +23,9 @@ func RegisterDefaultDeserializer(metaFactory func() s.ParseNodeFactory) {
 	contentType, err := factory.GetValidContentType()
 	if err == nil && contentType != "" {
 		registry := s.DefaultParseNodeFactoryInstance
-		registry.Lock.Lock()
+		registry.Lock()
 		registry.ContentTypeAssociatedFactories[contentType] = factory
-		registry.Lock.Unlock()
+		registry.Unlock()
 	}
 }
 
@@ -66,9 +66,9 @@ func EnableBackingStoreForParseNodeFactory(factory s.ParseNodeFactory) s.ParseNo
 func enableBackingStoreForParseNodeRegistry(registry *s.ParseNodeFactoryRegistry) {
 	for key, value := range registry.ContentTypeAssociatedFactories {
 		if _, ok := value.(*store.BackingStoreParseNodeFactory); !ok {
-			registry.Lock.Lock()
+			registry.Lock()
 			registry.ContentTypeAssociatedFactories[key] = store.NewBackingStoreParseNodeFactory(value)
-			registry.Lock.Unlock()
+			registry.Unlock()
 		}
 	}
 }

--- a/api_client_builder.go
+++ b/api_client_builder.go
@@ -11,8 +11,8 @@ import (
 // serialization.SerializationWriterFactoryRegistry objects to ensure that they are not written to concurrently.
 var serializerMutex sync.Mutex
 
-// deserializerMutex is used when accessing fields of serialization.ParseNodeFactory
-// objects to ensure that they are not written to concurrently.
+// deserializerMutex is used when accessing fields of serialization.ParseNodeFactory or
+// serialization.ParseNodeFactoryRegistry objects to ensure that they are not written to concurrently.
 var deserializerMutex sync.Mutex
 
 // RegisterDefaultSerializer registers the default serializer to the registry singleton to be used by the request adapter.
@@ -74,7 +74,9 @@ func EnableBackingStoreForParseNodeFactory(factory s.ParseNodeFactory) s.ParseNo
 func enableBackingStoreForParseNodeRegistry(registry *s.ParseNodeFactoryRegistry) {
 	for key, value := range registry.ContentTypeAssociatedFactories {
 		if _, ok := value.(*store.BackingStoreParseNodeFactory); !ok {
+			deserializerMutex.Lock()
 			registry.ContentTypeAssociatedFactories[key] = store.NewBackingStoreParseNodeFactory(value)
+			deserializerMutex.Unlock()
 		}
 	}
 }

--- a/api_client_builder.go
+++ b/api_client_builder.go
@@ -7,8 +7,8 @@ import (
 	s "github.com/microsoft/kiota-abstractions-go/serialization"
 )
 
-// serializerMutex is used when accessing fields of serialization.SerializationWriterFactory
-// objects to ensure that they are not written to concurrently.
+// serializerMutex is used when accessing fields of serialization.SerializationWriterFactory or
+// serialization.SerializationWriterFactoryRegistry objects to ensure that they are not written to concurrently.
 var serializerMutex sync.Mutex
 
 // deserializerMutex is used when accessing fields of serialization.ParseNodeFactory
@@ -52,7 +52,9 @@ func EnableBackingStoreForSerializationWriterFactory(factory s.SerializationWrit
 func enableBackingStoreForSerializationRegistry(registry *s.SerializationWriterFactoryRegistry) {
 	for key, value := range registry.ContentTypeAssociatedFactories {
 		if _, ok := value.(*store.BackingStoreSerializationWriterProxyFactory); !ok {
+			serializerMutex.Lock()
 			registry.ContentTypeAssociatedFactories[key] = store.NewBackingStoreSerializationWriterProxyFactory(value)
+			serializerMutex.Unlock()
 		}
 	}
 }

--- a/api_client_builder.go
+++ b/api_client_builder.go
@@ -11,9 +11,9 @@ func RegisterDefaultSerializer(metaFactory func() s.SerializationWriterFactory) 
 	contentType, err := factory.GetValidContentType()
 	if err == nil && contentType != "" {
 		registry := s.DefaultSerializationWriterFactoryInstance
-		registry.Lock.Lock()
+		registry.Lock()
 		registry.ContentTypeAssociatedFactories[contentType] = factory
-		registry.Lock.Unlock()
+		registry.Unlock()
 	}
 }
 
@@ -44,9 +44,9 @@ func EnableBackingStoreForSerializationWriterFactory(factory s.SerializationWrit
 func enableBackingStoreForSerializationRegistry(registry *s.SerializationWriterFactoryRegistry) {
 	for key, value := range registry.ContentTypeAssociatedFactories {
 		if _, ok := value.(*store.BackingStoreSerializationWriterProxyFactory); !ok {
-			registry.Lock.Lock()
+			registry.Lock()
 			registry.ContentTypeAssociatedFactories[key] = store.NewBackingStoreSerializationWriterProxyFactory(value)
-			registry.Lock.Unlock()
+			registry.Unlock()
 		}
 	}
 }

--- a/internal/mock_serializer.go
+++ b/internal/mock_serializer.go
@@ -164,8 +164,6 @@ type MockParseNodeFactory struct {
 }
 
 func NewMockParseNodeFactory() *MockParseNodeFactory {
-	registry := serialization.ParseNodeFactoryRegistry{
-		ContentTypeAssociatedFactories: make(map[string]serialization.ParseNodeFactory),
-	}
-	return &MockParseNodeFactory{registry}
+	registry := serialization.NewParseNodeFactoryRegistry()
+	return &MockParseNodeFactory{*registry}
 }

--- a/serialization/parse_node_factory_registry.go
+++ b/serialization/parse_node_factory_registry.go
@@ -9,18 +9,17 @@ import (
 
 // ParseNodeFactoryRegistry holds a list of all the registered factories for the various types of nodes.
 type ParseNodeFactoryRegistry struct {
-	// Lock should be used when accessing other fields of this struct to ensure thread safety.
-	Lock *sync.Mutex
+	lock *sync.Mutex
 
 	// ContentTypeAssociatedFactories maps content types onto the relevant factory.
 	//
-	// When interacting with this field, please make use of Lock to ensure thread safety.
+	// When interacting with this field, please make use of Lock and Unlock methods to ensure thread safety.
 	ContentTypeAssociatedFactories map[string]ParseNodeFactory
 }
 
 func NewParseNodeFactoryRegistry() *ParseNodeFactoryRegistry {
 	return &ParseNodeFactoryRegistry{
-		Lock:                           &sync.Mutex{},
+		lock:                           &sync.Mutex{},
 		ContentTypeAssociatedFactories: make(map[string]ParseNodeFactory),
 	}
 }
@@ -54,4 +53,12 @@ func (m *ParseNodeFactoryRegistry) GetRootParseNode(contentType string, content 
 		return factory.GetRootParseNode(cleanedContentType, content)
 	}
 	return nil, errors.New("content type " + cleanedContentType + " does not have a factory registered to be parsed")
+}
+
+func (m *ParseNodeFactoryRegistry) Lock() {
+	m.lock.Lock()
+}
+
+func (m *ParseNodeFactoryRegistry) Unlock() {
+	m.lock.Unlock()
 }

--- a/serialization/parse_node_factory_registry.go
+++ b/serialization/parse_node_factory_registry.go
@@ -4,17 +4,29 @@ import (
 	"errors"
 	re "regexp"
 	"strings"
+	"sync"
 )
 
 // ParseNodeFactoryRegistry holds a list of all the registered factories for the various types of nodes.
 type ParseNodeFactoryRegistry struct {
+	// Lock should be used when accessing other fields of this struct to ensure thread safety.
+	Lock *sync.Mutex
+
+	// ContentTypeAssociatedFactories maps content types onto the relevant factory.
+	//
+	// When interacting with this field, please make use of Lock to ensure thread safety.
 	ContentTypeAssociatedFactories map[string]ParseNodeFactory
 }
 
-// DefaultParseNodeFactoryInstance is the default singleton instance of the registry to be used when registering new factories that should be available by default.
-var DefaultParseNodeFactoryInstance = &ParseNodeFactoryRegistry{
-	ContentTypeAssociatedFactories: make(map[string]ParseNodeFactory),
+func NewParseNodeFactoryRegistry() *ParseNodeFactoryRegistry {
+	return &ParseNodeFactoryRegistry{
+		Lock:                           &sync.Mutex{},
+		ContentTypeAssociatedFactories: make(map[string]ParseNodeFactory),
+	}
 }
+
+// DefaultParseNodeFactoryInstance is the default singleton instance of the registry to be used when registering new factories that should be available by default.
+var DefaultParseNodeFactoryInstance = NewParseNodeFactoryRegistry()
 
 // GetValidContentType returns the valid content type for the ParseNodeFactoryRegistry
 func (m *ParseNodeFactoryRegistry) GetValidContentType() (string, error) {

--- a/serialization/serialization_writer_factory_registry.go
+++ b/serialization/serialization_writer_factory_registry.go
@@ -8,18 +8,17 @@ import (
 
 // SerializationWriterFactoryRegistry is a factory holds a list of all the registered factories for the various types of nodes.
 type SerializationWriterFactoryRegistry struct {
-	// Lock should be used when accessing other fields of this struct to ensure thread safety.
-	Lock *sync.Mutex
+	lock *sync.Mutex
 
 	// ContentTypeAssociatedFactories list of factories that are registered by content type.
 	//
-	// When interacting with this field, please make use of Lock to ensure thread safety.
+	// When interacting with this field, please make use of Lock and Unlock methods to ensure thread safety.
 	ContentTypeAssociatedFactories map[string]SerializationWriterFactory
 }
 
 func NewSerializationWriterFactoryRegistry() *SerializationWriterFactoryRegistry {
 	return &SerializationWriterFactoryRegistry{
-		Lock:                           &sync.Mutex{},
+		lock:                           &sync.Mutex{},
 		ContentTypeAssociatedFactories: make(map[string]SerializationWriterFactory),
 	}
 }
@@ -48,4 +47,12 @@ func (m *SerializationWriterFactoryRegistry) GetSerializationWriter(contentType 
 		return factory.GetSerializationWriter(cleanedContentType)
 	}
 	return nil, errors.New("Content type " + cleanedContentType + " does not have a factory registered to be parsed")
+}
+
+func (m *SerializationWriterFactoryRegistry) Lock() {
+	m.lock.Lock()
+}
+
+func (m *SerializationWriterFactoryRegistry) Unlock() {
+	m.lock.Unlock()
 }

--- a/serialization/serialization_writer_factory_registry.go
+++ b/serialization/serialization_writer_factory_registry.go
@@ -3,18 +3,29 @@ package serialization
 import (
 	"errors"
 	"strings"
+	"sync"
 )
 
 // SerializationWriterFactoryRegistry is a factory holds a list of all the registered factories for the various types of nodes.
 type SerializationWriterFactoryRegistry struct {
+	// Lock should be used when accessing other fields of this struct to ensure thread safety.
+	Lock *sync.Mutex
+
 	// ContentTypeAssociatedFactories list of factories that are registered by content type.
+	//
+	// When interacting with this field, please make use of Lock to ensure thread safety.
 	ContentTypeAssociatedFactories map[string]SerializationWriterFactory
 }
 
-// DefaultSerializationWriterFactoryInstance is the default singleton instance of the registry to be used when registering new factories that should be available by default.
-var DefaultSerializationWriterFactoryInstance = &SerializationWriterFactoryRegistry{
-	ContentTypeAssociatedFactories: make(map[string]SerializationWriterFactory),
+func NewSerializationWriterFactoryRegistry() *SerializationWriterFactoryRegistry {
+	return &SerializationWriterFactoryRegistry{
+		Lock:                           &sync.Mutex{},
+		ContentTypeAssociatedFactories: make(map[string]SerializationWriterFactory),
+	}
 }
+
+// DefaultSerializationWriterFactoryInstance is the default singleton instance of the registry to be used when registering new factories that should be available by default.
+var DefaultSerializationWriterFactoryInstance = NewSerializationWriterFactoryRegistry()
 
 // GetValidContentType returns the valid content type for the SerializationWriterFactoryRegistry
 func (m *SerializationWriterFactoryRegistry) GetValidContentType() (string, error) {


### PR DESCRIPTION
This PR aims to fix panics caused by concurrent writes to maps. See #75 and #54 for background.

Relevant changes:

- Moved package level locks with into relevant structs as fields
- Make use of these fields where previously the package level locks were used

General thoughts:

- Using the locks for now seems to be the responsibility of the users. Changing that would require touching every code directly acessing the structs field and that is probably a bit much for this PR.