### PR TITLE
Adds URL replacement parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [0.19.1] - 2023-04-12
+## [0.20.0] - 2023-04-13
 
 ### Added
+
+- Adds UrlReplacementPairs accessor and methods to allow url token replacements
+
+## [0.19.1] - 2023-04-12
 
 ### Changed
 

--- a/request_adapter.go
+++ b/request_adapter.go
@@ -42,6 +42,8 @@ type RequestAdapter interface {
 	SetBaseUrl(baseUrl string)
 	// GetBaseUrl gets the base url for every request.
 	GetBaseUrl() string
-	// ConvertToNativeRequest converts the given RequestInformation into a native HTTP request.
-	ConvertToNativeRequest(context context.Context, requestInfo *RequestInformation) (any, error)
+	// SetUrlReplacementPairs sets the value of the url replacement pairs.
+	SetUrlReplacementPairs(map[string]string)
+	// GetUrlReplacementPairs returns url replacement pairs provided by the users.
+	GetUrlReplacementPairs() map[string]string
 }

--- a/request_information.go
+++ b/request_information.go
@@ -49,8 +49,13 @@ func NewRequestInformation() *RequestInformation {
 	}
 }
 
-// GetUri returns the URI of the request.
+// GetUri returns the URI of the request. Invokes GetReplacedUri without any values
 func (request *RequestInformation) GetUri() (*u.URL, error) {
+	return request.GetReplacedUri(make(map[string]string))
+}
+
+// GetReplacedUri returns the URI of the request.
+func (request *RequestInformation) GetReplacedUri(replacementPairs map[string]string) (*u.URL, error) {
 	if request.uri != nil {
 		return request.uri, nil
 	} else if request.UrlTemplate == "" {
@@ -92,9 +97,18 @@ func (request *RequestInformation) GetUri() (*u.URL, error) {
 		if err != nil {
 			return nil, err
 		}
+		url = replaceTokens(url, replacementPairs)
 		uri, err := u.Parse(url)
 		return uri, err
 	}
+}
+
+// replaceTokens replaces url tokens with provided variables.
+func replaceTokens(url string, replacementPairs map[string]string) string {
+	for key, value := range replacementPairs {
+		url = strings.Replace(url, key, value, 1)
+	}
+	return url
 }
 
 // addParameterWithOriginalName adds the URI template parameter to the template using the right casing, because of go conventions, casing might have changed for the generated property

--- a/request_information_test.go
+++ b/request_information_test.go
@@ -76,6 +76,15 @@ func TestItSetsTheRawURL(t *testing.T) {
 	assert.Equal(t, 0, len(requestInformation.QueryParameters))
 }
 
+func TestGetReplacedUri(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "https://someurl.com/users/me-token-to-replace/contactFolders"
+	uri, err := requestInformation.GetReplacedUri(map[string]string{"/users/me-token-to-replace": "/me"})
+	assert.Nil(t, err)
+	assert.Equal(t, "https://someurl.com/me/contactFolders", uri.String())
+	assert.Equal(t, 0, len(requestInformation.QueryParameters))
+}
+
 type getQueryParameters struct {
 	Count          *bool    `uriparametername:"%24count"`
 	Expand         []string `uriparametername:"%24expand"`
@@ -250,6 +259,11 @@ type MockRequestAdapter struct {
 	SerializationWriterFactory s.SerializationWriterFactory
 }
 
+func (r *MockRequestAdapter) SetUrlReplacementPairs(map[string]string) {
+}
+func (r *MockRequestAdapter) GetUrlReplacementPairs() map[string]string {
+	return nil
+}
 func (r *MockRequestAdapter) Send(context context.Context, requestInfo *RequestInformation, constructor s.ParsableFactory, errorMappings ErrorMappings) (s.Parsable, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Introduces getter and accessor methods for url replacement parameters. The work in part of this [issue](https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/179).

Migrating of url replacement logic from RequestOptions to Request Adapter to allow centralized processing of url replacement tokens