### PR TITLE
Adds response headers to API Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Adds response headers to Api Error class
+
 ### Changed
 
 ## [0.19.1] - 2023-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.20.0] - 2023-04-12
+
+### Added
+
+- Adds response headers to Api Error class
+### Changed
+
 ## [0.19.1] - 2023-04-12
 
 ### Added

--- a/api_error.go
+++ b/api_error.go
@@ -19,5 +19,5 @@ func (e *ApiError) Error() string {
 
 // NewApiError creates a new ApiError instance
 func NewApiError() *ApiError {
-	return &ApiError{}
+	return &ApiError{ResponseHeaders: NewResponseHeaders()}
 }

--- a/api_error.go
+++ b/api_error.go
@@ -6,7 +6,7 @@ import "fmt"
 type ApiError struct {
 	Message            string
 	ResponseStatusCode int
-	ResponseHeaders    ResponseHeaders
+	ResponseHeaders    *ResponseHeaders
 }
 
 func (e *ApiError) Error() string {

--- a/api_error.go
+++ b/api_error.go
@@ -6,6 +6,7 @@ import "fmt"
 type ApiError struct {
 	Message            string
 	ResponseStatusCode int
+	ResponseHeaders    ResponseHeaders
 }
 
 func (e *ApiError) Error() string {

--- a/headers.go
+++ b/headers.go
@@ -1,0 +1,111 @@
+package abstractions
+
+import "strings"
+
+type header struct {
+	headers map[string]map[string]struct{}
+}
+
+type void struct{}
+
+var voidInstance void
+
+func normalizeHeaderKey(key string) string {
+	return strings.ToLower(strings.Trim(key, " "))
+}
+
+//Add adds a new header or append a new value to an existing header
+func (r *header) Add(key string, value string, additionalValues ...string) {
+	normalizedKey := normalizeHeaderKey(key)
+	if normalizedKey == "" || value == "" {
+		return
+	}
+	if r.headers == nil {
+		r.headers = make(map[string]map[string]struct{})
+	}
+	if r.headers[normalizedKey] == nil {
+		r.headers[normalizedKey] = make(map[string]struct{})
+	}
+	r.headers[normalizedKey][value] = voidInstance
+	for _, v := range additionalValues {
+		r.headers[normalizedKey][v] = voidInstance
+	}
+}
+
+//Get returns the values for the specific header
+func (r *header) Get(key string) []string {
+	if r.headers == nil {
+		return nil
+	}
+	normalizedKey := normalizeHeaderKey(key)
+	if r.headers[normalizedKey] == nil {
+		return make([]string, 0)
+	}
+	values := make([]string, 0, len(r.headers[normalizedKey]))
+	for k := range r.headers[normalizedKey] {
+		values = append(values, k)
+	}
+	return values
+}
+
+//Remove removes the specific header and all its values
+func (r *header) Remove(key string) {
+	if r.headers == nil {
+		return
+	}
+	normalizedKey := normalizeHeaderKey(key)
+	delete(r.headers, normalizedKey)
+}
+
+//RemoveValue remove the value for the specific header
+func (r *header) RemoveValue(key string, value string) {
+	if r.headers == nil {
+		return
+	}
+	normalizedKey := normalizeHeaderKey(key)
+	if r.headers[normalizedKey] == nil {
+		return
+	}
+	delete(r.headers[normalizedKey], value)
+	if len(r.headers[normalizedKey]) == 0 {
+		delete(r.headers, normalizedKey)
+	}
+}
+
+//ContainsKey check if the key exists in the headers
+func (r *header) ContainsKey(key string) bool {
+	if r.headers == nil {
+		return false
+	}
+	normalizedKey := normalizeHeaderKey(key)
+	return r.headers[normalizedKey] != nil
+}
+
+//Clear clear all headers
+func (r *header) Clear() {
+	r.headers = nil
+}
+
+//AddAll adds all headers from the other headers
+func (r *header) AddAll(other *header) {
+	if other == nil || other.headers == nil {
+		return
+	}
+	for k, v := range other.headers {
+		for k2 := range v {
+			r.Add(k, k2)
+		}
+	}
+}
+
+//ListKeys returns all the keys in the headers
+func (r *header) ListKeys() []string {
+	if r.headers == nil {
+		return make([]string, 0)
+	}
+	keys := make([]string, 0, len(r.headers))
+	for k := range r.headers {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/response_headers.go
+++ b/response_headers.go
@@ -1,19 +1,19 @@
 package abstractions
 
-//RequestHeaders represents a collection of request headers
-type RequestHeaders struct {
+//ResponseHeaders represents a collection of response headers
+type ResponseHeaders struct {
 	header
 }
 
-//NewRequestHeaders creates a new RequestHeaders
-func NewRequestHeaders() *RequestHeaders {
-	return &RequestHeaders{
+//NewResponseHeaders creates a new ResponseHeaders
+func NewResponseHeaders() *ResponseHeaders {
+	return &ResponseHeaders{
 		header{make(map[string]map[string]struct{})},
 	}
 }
 
 //AddAll adds all headers from the other headers
-func (r *RequestHeaders) AddAll(other *RequestHeaders) {
+func (r *ResponseHeaders) AddAll(other *ResponseHeaders) {
 	if other == nil || other.headers == nil {
 		return
 	}


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota/issues/2524

Moves methods to generic `headers` struct to allow for a ResponseHeaders collection to share case insenstivitive functionality. 