### PR TITLE
add ApiErrorable interface

### DIFF
--- a/api_error.go
+++ b/api_error.go
@@ -2,6 +2,11 @@ package abstractions
 
 import "fmt"
 
+type ApiErrorable interface {
+	SetResponseHeaders(ResponseHeaders *ResponseHeaders)
+	SetStatusCode(ResponseStatusCode int)
+}
+
 // ApiError is the parent type for errors thrown by the client when receiving failed responses to its requests
 type ApiError struct {
 	Message            string
@@ -20,4 +25,12 @@ func (e *ApiError) Error() string {
 // NewApiError creates a new ApiError instance
 func NewApiError() *ApiError {
 	return &ApiError{ResponseHeaders: NewResponseHeaders()}
+}
+
+func (e *ApiError) SetResponseHeaders(ResponseHeaders *ResponseHeaders) {
+	e.ResponseHeaders = ResponseHeaders
+}
+
+func (e *ApiError) SetStatusCode(ResponseStatusCode int) {
+	e.ResponseStatusCode = ResponseStatusCode
 }


### PR DESCRIPTION
To fix this issue: https://github.com/microsoft/kiota-http-go/issues/110
I added a ApiErrorable interface as @baywet suggested. 