### PR TITLE
Parameters with lists of numbers not supported in URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.5.3] - 2023-11-24
+
+### Added
+
+- Added support for multi valued query and path parameters of type other than string. [#124](https://github.com/microsoft/kiota-abstractions-go/pull/124)
+
 ## [1.5.2] - 2023-11-22
 
 ### Added

--- a/request_information_test.go
+++ b/request_information_test.go
@@ -103,6 +103,18 @@ type getQueryParameters struct {
 	Filter         *string  `uriparametername:"%24filter"`
 	Orderby        []string `uriparametername:"%24orderby"`
 	Search         *string  `uriparametername:"%24search"`
+	Number         []int64  `uriparametername:"%24number"`
+}
+
+func TestItSetsNumberArrayQueryParameters(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/me{?%24number}"
+	requestInformation.AddQueryParameters(getQueryParameters{
+		Number: []int64{1, 2, 4},
+	})
+	resultUri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost/me?%24number=1,2,4", resultUri.String())
 }
 
 func TestItSetsSelectAndCountQueryParameters(t *testing.T) {


### PR DESCRIPTION
`AddQueryParameters` only checks for `[]string`, `[]any` and (slices of) enum types. Kiota however also constructs query parameters with types like `[]int64`. These do not satisfy any of the current checks and are therefor never rendered in the resulting URI.