### PR TITLE
fix: Add Accessors for ApiErrorable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Added
+
+## [1.7.0] - 2024-07-09
+
+-  Added accessors for headers and status to `ApiErrorable`  [#177](https://github.com/microsoft/kiota-abstractions-go/issues/177)
+
+### Changed
+
 ## [1.6.1] - 2024-07-09
 
 - Corrected two instances of `octet-steam` to `octet-stream` [#173](https://github.com/microsoft/kiota-abstractions-go/pull/173), [#174](https://github.com/microsoft/kiota-abstractions-go/pull/174)

--- a/api_error.go
+++ b/api_error.go
@@ -5,6 +5,8 @@ import "fmt"
 type ApiErrorable interface {
 	SetResponseHeaders(ResponseHeaders *ResponseHeaders)
 	SetStatusCode(ResponseStatusCode int)
+	GetResponseHeaders() *ResponseHeaders
+	GetStatusCode() int
 }
 
 // ApiError is the parent type for errors thrown by the client when receiving failed responses to its requests
@@ -33,4 +35,12 @@ func (e *ApiError) SetResponseHeaders(ResponseHeaders *ResponseHeaders) {
 
 func (e *ApiError) SetStatusCode(ResponseStatusCode int) {
 	e.ResponseStatusCode = ResponseStatusCode
+}
+
+func (e *ApiError) GetResponseHeaders() *ResponseHeaders {
+	return e.ResponseHeaders
+}
+
+func (e *ApiError) GetStatusCode() int {
+	return e.ResponseStatusCode
 }


### PR DESCRIPTION
Resolves https://github.com/microsoft/kiota-abstractions-go/issues/177

Adds gettors for ApiErrorable status code and headers