### PR TITLE
fix: match the input precision during TimeOnly.String() formatting

### DIFF
--- a/request_information_test.go
+++ b/request_information_test.go
@@ -346,16 +346,18 @@ func TestItNormalizesOnStandardizedTimeOnlyParams(t *testing.T) {
 	singleValue := *value
 
 	time2, err := s.ParseTimeOnly("16:20:21.000")
+	assert.Nil(t, err)
 	referenceArray := []*s.TimeOnly{
 		time2,
 	}
 
 	referenceValue, err := s.ParseTimeOnly("16:20:21.000")
+	assert.Nil(t, err)
 
 	requestInformation := prepareNormalizedStdTest(arrayValues, singleValue, referenceArray, referenceValue)
 	resultUri, err := requestInformation.GetUri()
 	assert.Nil(t, err)
-	assert.Equal(t, "http://localhost/array/16%3A20%3A21.000000000/single/16%3A20%3A21.000000000/referenceArray/16%3A20%3A21.000000000/referenceValue/16%3A20%3A21.000000000", resultUri.String())
+	assert.Equal(t, "http://localhost/array/16%3A20%3A21.000/single/16%3A20%3A21.000/referenceArray/16%3A20%3A21.000/referenceValue/16%3A20%3A21.000", resultUri.String())
 }
 
 func TestItNormalizesOnStandardizedDateOnlyParams(t *testing.T) {

--- a/serialization/duration.go
+++ b/serialization/duration.go
@@ -59,7 +59,7 @@ func durationFromString(dur string) (*duration, error) {
 			continue
 		}
 
-		val, err := strconv.ParseFloat(part, 10)
+		val, err := strconv.ParseFloat(part, 64)
 		if err != nil {
 			return nil, err
 		}

--- a/serialization/kiota_serializer.go
+++ b/serialization/kiota_serializer.go
@@ -61,7 +61,7 @@ func getParseNode(contentType string, content []byte, parsableFactory ParsableFa
 	if contentType == "" {
 		return nil, errors.New("the content type is empty")
 	}
-	if content == nil || len(content) == 0 {
+	if len(content) == 0 {
 		return nil, errors.New("the content is empty")
 	}
 	if parsableFactory == nil {

--- a/serialization/parse_node_factory_registry.go
+++ b/serialization/parse_node_factory_registry.go
@@ -32,7 +32,7 @@ func (m *ParseNodeFactoryRegistry) GetValidContentType() (string, error) {
 	return "", errors.New("the registry supports multiple content types. Get the registered factory instead")
 }
 
-var contentTypeVendorCleanupPattern = re.MustCompile("[^/]+\\+")
+var contentTypeVendorCleanupPattern = re.MustCompile(`[^/]+\+`)
 
 // GetRootParseNode returns a new ParseNode instance that is the root of the content
 func (m *ParseNodeFactoryRegistry) GetRootParseNode(contentType string, content []byte) (ParseNode, error) {

--- a/serialization/time_only.go
+++ b/serialization/time_only.go
@@ -1,14 +1,15 @@
 package serialization
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
 
 // TimeOnly is represents the time part of a date time (time) value.
 type TimeOnly struct {
-	time time.Time
+	time      time.Time
+	precision int // number of decimal places for nanoseconds
 }
 
 const timeOnlyFormat = "15:04:05.000000000"
@@ -28,35 +29,44 @@ var timeOnlyParsingFormats = map[int]string{
 
 // String returns the time only as a string following the RFC3339 standard.
 func (t TimeOnly) String() string {
-	return t.time.Format(timeOnlyFormat)
+	if t.precision == 0 {
+		return t.time.Format("15:04:05")
+	}
+	return t.time.Format(timeOnlyParsingFormats[t.precision])
 }
 
 // ParseTimeOnly parses a string into a TimeOnly following the RFC3339 standard.
 func ParseTimeOnly(s string) (*TimeOnly, error) {
-	if len(strings.TrimSpace(s)) <= 0 {
+	s = strings.TrimSpace(s)
+	if s == "" {
 		return nil, nil
 	}
-	splat := strings.Split(s, ".")
-	parsingFormat := timeOnlyParsingFormats[0]
-	if len(splat) > 1 {
-		dotSectionLen := len(splat[1])
-		if dotSectionLen >= len(timeOnlyParsingFormats) {
-			return nil, errors.New("too many decimal places in time only string")
+
+	precision := 0
+	if parts := strings.Split(s, "."); len(parts) > 1 {
+		precision = len(parts[1])
+		if precision >= len(timeOnlyParsingFormats) {
+			return nil, fmt.Errorf("time precision of %d exceeds maximum allowed of %d", precision, len(timeOnlyParsingFormats)-1)
 		}
-		parsingFormat = timeOnlyParsingFormats[dotSectionLen]
 	}
-	timeValue, err := time.Parse(parsingFormat, s)
+
+	timeValue, err := time.Parse(timeOnlyParsingFormats[precision], s)
 	if err != nil {
 		return nil, err
 	}
-	return &TimeOnly{
-		time: timeValue,
-	}, nil
+
+	return &TimeOnly{time: timeValue, precision: precision}, nil
 }
 
 // NewTimeOnly creates a new TimeOnly from a time.Time.
 func NewTimeOnly(t time.Time) *TimeOnly {
+	precision := 0
+	nanos := t.Nanosecond()
+	if nanos > 0 {
+		precision = len(strings.TrimRight(fmt.Sprintf("%09d", nanos), "0"))
+	}
 	return &TimeOnly{
-		time: t,
+		time:      t,
+		precision: precision,
 	}
 }

--- a/serialization/time_only_test.go
+++ b/serialization/time_only_test.go
@@ -1,34 +1,138 @@
 package serialization
 
 import (
-	assert "github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
 
-func TestItParsesATimeOnly(t *testing.T) {
-	dateOnly, err := ParseTimeOnly("16:20:21.000")
-	assert.Nil(t, err)
-	assert.Equal(t, "16:20:21.000000000", dateOnly.String())
+func TestParseTimeOnly(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantTime    string
+		wantError   bool
+		wantNil     bool // add this field to explicitly check for nil returns
+		precision   int
+		errorString string
+	}{
+		{"basic time", "15:04:05", "15:04:05", false, false, 0, ""},
+		{"one decimal", "15:04:05.1", "15:04:05.1", false, false, 1, ""},
+		{"three decimals", "15:04:05.123", "15:04:05.123", false, false, 3, ""},
+		{"max decimals", "15:04:05.123456789", "15:04:05.123456789", false, false, 9, ""},
+		{"empty string", "", "", false, true, 0, ""}, // update to expect nil
+		{"whitespace", "  ", "", false, true, 0, ""}, // update to expect nil
+		{"too many decimals", "15:04:05.1234567890", "", true, false, 0, "time precision of 10 exceeds maximum allowed of 9"},
+		{"invalid time", "25:04:05", "", true, false, 0, ""},
+		{"leading zeros", "05:04:05", "05:04:05", false, false, 0, ""},
+		{"leading zeros with precision", "05:04:05.123", "05:04:05.123", false, false, 3, ""},
+		{"invalid format", "5:4:5", "", true, false, 0, ""},
+		{"invalid minutes", "05:60:05", "", true, false, 0, ""},
+		{"invalid seconds", "05:04:60", "", true, false, 0, ""},
+		{"missing seconds", "05:04", "", true, false, 0, ""},
+		{"extra components", "05:04:05:01", "", true, false, 0, ""},
+		{"trailing dot", "05:04:05.", "", true, false, 0, ""},
+		{"only dot decimal", "05:04:05.", "", true, false, 0, ""},
+		{"non-numeric decimal", "05:04:05.abc", "", true, false, 0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTimeOnly(tt.input)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ParseTimeOnly(%q) = %v, want nil", tt.input, got)
+				}
+				return
+			}
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("ParseTimeOnly(%q) expected error, got nil", tt.input)
+				}
+				if tt.errorString != "" && err.Error() != tt.errorString {
+					t.Errorf("ParseTimeOnly(%q) error = %v, want %v", tt.input, err, tt.errorString)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ParseTimeOnly(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+
+			if got == nil {
+				t.Errorf("ParseTimeOnly(%q) returned nil, want non-nil", tt.input)
+				return
+			}
+
+			if got.String() != tt.wantTime {
+				t.Errorf("ParseTimeOnly(%q) = %v, want %v", tt.input, got.String(), tt.wantTime)
+			}
+
+			if got.precision != tt.precision {
+				t.Errorf("ParseTimeOnly(%q) precision = %v, want %v", tt.input, got.precision, tt.precision)
+			}
+		})
+	}
 }
 
-func TestItParsesATimeOnlyNoDecimals(t *testing.T) {
-	dateOnly, err := ParseTimeOnly("16:20:21")
-	assert.Nil(t, err)
-	assert.Equal(t, "16:20:21.000000000", dateOnly.String())
+func TestNewTimeOnly(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     time.Time
+		wantTime  string
+		precision int
+	}{
+		{"no decimals", time.Date(2023, 1, 1, 15, 4, 5, 0, time.UTC), "15:04:05", 0},
+		{"three decimals", time.Date(2023, 1, 1, 15, 4, 5, 123000000, time.UTC), "15:04:05.123", 3},
+		{"six decimals", time.Date(2023, 1, 1, 15, 4, 5, 123456000, time.UTC), "15:04:05.123456", 6},
+		{"nine decimals", time.Date(2023, 1, 1, 15, 4, 5, 123456789, time.UTC), "15:04:05.123456789", 9},
+		{"trailing zeros", time.Date(2023, 1, 1, 15, 4, 5, 120000000, time.UTC), "15:04:05.12", 2},
+		{"all zeros", time.Date(2023, 1, 1, 15, 4, 5, 100000000, time.UTC), "15:04:05.1", 1},
+		{"zero hour", time.Date(2023, 1, 1, 0, 4, 5, 123000000, time.UTC), "00:04:05.123", 3},
+		{"midnight", time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), "00:00:00", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewTimeOnly(tt.input)
+			if got.String() != tt.wantTime {
+				t.Errorf("NewTimeOnly() = %v, want %v", got.String(), tt.wantTime)
+			}
+			if got.precision != tt.precision {
+				t.Errorf("NewTimeOnly() precision = %v, want %v", got.precision, tt.precision)
+			}
+		})
+	}
 }
 
-func TestItDoesntParseATimeOnlyWithTooManyDecimals(t *testing.T) {
-	_, err := ParseTimeOnly("2020-01-04T15:04:05.00000000000000000000")
-	assert.NotNil(t, err)
-}
+func TestTimeOnly_String(t *testing.T) {
+	tests := []struct {
+		name      string
+		time      time.Time
+		precision int
+		want      string
+	}{
+		{"zero precision", time.Date(2023, 1, 1, 15, 4, 5, 123456789, time.UTC), 0, "15:04:05"},
+		{"precision 3", time.Date(2023, 1, 1, 15, 4, 5, 123456789, time.UTC), 3, "15:04:05.123"},
+		{"precision 6", time.Date(2023, 1, 1, 15, 4, 5, 123456789, time.UTC), 6, "15:04:05.123456"},
+		{"precision 9", time.Date(2023, 1, 1, 15, 4, 5, 123456789, time.UTC), 9, "15:04:05.123456789"},
+		{"midnight zero precision", time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), 0, "00:00:00"},
+		{"midnight with precision", time.Date(2023, 1, 1, 0, 0, 0, 100000000, time.UTC), 1, "00:00:00.1"},
+		{"leading zero minutes", time.Date(2023, 1, 1, 15, 4, 5, 0, time.UTC), 0, "15:04:05"},
+		{"leading zero everything", time.Date(2023, 1, 1, 5, 4, 5, 0, time.UTC), 0, "05:04:05"},
+	}
 
-func TestItDoesntParseAFullDateATimeOnly(t *testing.T) {
-	_, err := ParseTimeOnly("2020-01-04T15:04:05.00000")
-	assert.NotNil(t, err)
-}
-
-func TestItCreateANewTimeOnly(t *testing.T) {
-	dateOnly := NewTimeOnly(time.Date(1, 1, 1, 16, 20, 21, 0, time.UTC))
-	assert.Equal(t, "16:20:21.000000000", dateOnly.String())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeOnly := TimeOnly{
+				time:      tt.time,
+				precision: tt.precision,
+			}
+			if got := timeOnly.String(); got != tt.want {
+				t.Errorf("TimeOnly.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Closes #202 

# Description

Added a fix for getting the `TimeOnly.String()` value with the precision of the time passed in.