### PR TITLE
Handle map-style query parameters with nil values

### DIFF
--- a/request_information.go
+++ b/request_information.go
@@ -137,6 +137,19 @@ func castItem[T any, R interface{}](collection []T, mutator func(t T) R) []R {
 	return nil
 }
 
+func isNil(val any) bool {
+	if val == nil {
+		return true
+	}
+	v := reflect.ValueOf(val)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
 // sanitizeMap converts any map[string]V to map[string]any by applying convert
 // to each value. Entries for which convert returns false are omitted, which is
 // used to skip nil/undefined values per RFC 6570 §2.3 "undefined" semantics.
@@ -151,7 +164,7 @@ func sanitizeMap[V any](m map[string]V, convert func(v V) (any, bool)) map[strin
 }
 
 func (request *RequestInformation) sanitizeValue(value any) any {
-	if value == nil {
+	if isNil(value) {
 		return nil
 	}
 
@@ -218,10 +231,14 @@ func (request *RequestInformation) sanitizeValue(value any) any {
 	case map[string]any:
 		// Re-sanitize in case any values still need conversion (e.g. nil entries).
 		return sanitizeMap(v, func(val any) (any, bool) {
-			if val == nil {
+			if isNil(val) {
 				return nil, false
 			}
-			return request.sanitizeValue(val), true
+			sVal := request.sanitizeValue(val)
+			if isNil(sVal) {
+				return nil, false
+			}
+			return sVal, true
 		})
 	}
 
@@ -593,10 +610,10 @@ func (request *RequestInformation) AddQueryParameters(source any) {
 			fieldName = tagValue
 		}
 		value := request.sanitizeValue(fieldValue.Interface())
-		valueOfValue := reflect.ValueOf(value)
-		if valueOfValue.IsNil() {
+		if isNil(value) {
 			continue
 		}
+		valueOfValue := reflect.ValueOf(value)
 		str, ok := value.(*string)
 		if ok && str != nil {
 			request.QueryParameters[fieldName] = *str

--- a/request_information.go
+++ b/request_information.go
@@ -137,6 +137,19 @@ func castItem[T any, R interface{}](collection []T, mutator func(t T) R) []R {
 	return nil
 }
 
+// sanitizeMap converts any map[string]V to map[string]any by applying convert
+// to each value. Entries for which convert returns false are omitted, which is
+// used to skip nil/undefined values per RFC 6570 §2.3 "undefined" semantics.
+func sanitizeMap[V any](m map[string]V, convert func(v V) (any, bool)) map[string]any {
+	sanitized := make(map[string]any, len(m))
+	for k, v := range m {
+		if converted, ok := convert(v); ok {
+			sanitized[k] = converted
+		}
+	}
+	return sanitized
+}
+
 func (request *RequestInformation) sanitizeValue(value any) any {
 	if value == nil {
 		return nil
@@ -190,6 +203,25 @@ func (request *RequestInformation) sanitizeValue(value any) any {
 	case []s.DateOnly:
 		return castItem(v, func(v s.DateOnly) string {
 			return v.String()
+		})
+	case map[string]*string:
+		// Map-style query parameter (nullable values): drop nil entries per
+		// RFC 6570 §2.3 "undefined" semantics; dereference remaining pointers.
+		return sanitizeMap(v, func(ptr *string) (any, bool) {
+			if ptr == nil {
+				return nil, false
+			}
+			return *ptr, true
+		})
+	case map[string]string:
+		return sanitizeMap(v, func(s string) (any, bool) { return s, true })
+	case map[string]any:
+		// Re-sanitize in case any values still need conversion (e.g. nil entries).
+		return sanitizeMap(v, func(val any) (any, bool) {
+			if val == nil {
+				return nil, false
+			}
+			return request.sanitizeValue(val), true
 		})
 	}
 
@@ -590,6 +622,9 @@ func (request *RequestInformation) AddQueryParameters(source any) {
 		}
 		if arr, ok := value.([]any); ok && len(arr) > 0 {
 			request.QueryParametersAny[fieldName] = arr
+		}
+		if mapAny, ok := value.(map[string]any); ok {
+			request.QueryParametersAny[fieldName] = mapAny
 		}
 		normalizedValue := request.normalizeParameters(valueOfValue, value, true)
 		if normalizedValue != nil {

--- a/request_information_test.go
+++ b/request_information_test.go
@@ -662,3 +662,22 @@ func TestItExpandsMapStringQueryParameter(t *testing.T) {
 	assert.Contains(t, uriStr, "filter=equals%28published%2Ctrue%29")
 	assert.Contains(t, uriStr, "sort=-createdAt")
 }
+
+func TestItOmitsNilSanitizedValuesInMapAnyQueryParameter(t *testing.T) {
+	type AnyMapQueryParameters struct {
+		Query map[string]any `uriparametername:"query"`
+	}
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/articles{?query*}"
+	requestInformation.AddQueryParameters(AnyMapQueryParameters{
+		Query: map[string]any{
+			"include": "author",
+			"empty":   []*time.Time{},
+			"nilVal":  nil,
+		},
+	})
+	uri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	uriStr := uri.String()
+	assert.Equal(t, "http://localhost/articles?include=author", uriStr)
+}

--- a/request_information_test.go
+++ b/request_information_test.go
@@ -547,3 +547,118 @@ func (r *MockRequestAdapter) SetBaseUrl(baseUrl string) {
 func (r *MockRequestAdapter) GetBaseUrl() string {
 	return ""
 }
+
+type MapQueryParameters struct {
+	Query map[string]*string `uriparametername:"query"`
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestItExpandsMapQueryParameterAsIndividualKeyValuePairs(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/articles{?query*}"
+	requestInformation.AddQueryParameters(MapQueryParameters{
+		Query: map[string]*string{
+			"filter": strPtr("equals(published,true)"),
+			"sort":   strPtr("-createdAt"),
+		},
+	})
+	uri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	uriStr := uri.String()
+	assert.Contains(t, uriStr, "?")
+	assert.Contains(t, uriStr, "filter=equals%28published%2Ctrue%29")
+	assert.Contains(t, uriStr, "sort=-createdAt")
+}
+
+func TestItOmitsNilValuesInMapQueryParameter(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/articles{?query*}"
+	requestInformation.AddQueryParameters(MapQueryParameters{
+		Query: map[string]*string{
+			"include": strPtr("author"),
+			"exclude": nil,
+		},
+	})
+	uri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	uriStr := uri.String()
+	assert.Contains(t, uriStr, "include=author")
+	assert.NotContains(t, uriStr, "exclude")
+}
+
+func TestItIncludesEmptyStringValueInMapQueryParameter(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/articles{?query*}"
+	requestInformation.AddQueryParameters(MapQueryParameters{
+		Query: map[string]*string{
+			"search": strPtr(""),
+		},
+	})
+	uri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.Contains(t, uri.String(), "search=")
+}
+
+func TestItProducesNoQueryStringForEmptyMap(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/articles{?query*}"
+	requestInformation.AddQueryParameters(MapQueryParameters{
+		Query: map[string]*string{},
+	})
+	uri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.NotContains(t, uri.String(), "?")
+}
+
+func TestItProducesNoQueryStringForAllNilMap(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/articles{?query*}"
+	requestInformation.AddQueryParameters(MapQueryParameters{
+		Query: map[string]*string{
+			"a": nil,
+			"b": nil,
+		},
+	})
+	uri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.NotContains(t, uri.String(), "?")
+}
+
+func TestItMixesMapAndScalarQueryParameters(t *testing.T) {
+	type MixedQueryParameters struct {
+		Query map[string]*string `uriparametername:"query"`
+		Top   *int32             `uriparametername:"top"`
+	}
+	top := int32(5)
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/articles{?query*,top}"
+	requestInformation.AddQueryParameters(MixedQueryParameters{
+		Query: map[string]*string{"filter": strPtr("active")},
+		Top:   &top,
+	})
+	uri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	uriStr := uri.String()
+	assert.Contains(t, uriStr, "filter=active")
+	assert.Contains(t, uriStr, "top=5")
+}
+
+func TestItExpandsMapStringQueryParameter(t *testing.T) {
+	type StringMapQueryParameters struct {
+		Query map[string]string `uriparametername:"query"`
+	}
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/articles{?query*}"
+	requestInformation.AddQueryParameters(StringMapQueryParameters{
+		Query: map[string]string{
+			"filter": "equals(published,true)",
+			"sort":   "-createdAt",
+		},
+	})
+	uri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	uriStr := uri.String()
+	assert.Contains(t, uriStr, "filter=equals%28published%2Ctrue%29")
+	assert.Contains(t, uriStr, "sort=-createdAt")
+}


### PR DESCRIPTION
Contributes to https://github.com/microsoft/kiota/issues/3800.

Map/dictionary values used as query parameters (from an OpenAPI type: object with additionalProperties field) are now sanitized before being passed to StdUriTemplate. A new generic helper sanitizeMap[V] (a sibling of the existing castItem[T,R] for slices) handles the common pattern: iterate a map[string]V, apply a converter, skip entries for which the converter returns false, and return map[string]any.

Three cases in sanitizeValue use it:
- map[string]*string: dereferences pointers, drops nil entries
- map[string]string: passes values through unchanged
- map[string]any: recursively re-sanitizes values, drops nil entries

The AddQueryParameters method routes the resulting map[string]any into QueryParametersAny so StdUriTemplate can expand it as an RFC 6570 composite variable (e.g. {?query*} -> ?k1=v1&k2=v2).

Adds seven test cases covering map expansion, nil-value omission, empty-string inclusion, empty maps, all-nil maps, mixed scalar+map parameters, and the map[string]string variant.