### PR TITLE
feat: adds support for wildcard host validation

### DIFF
--- a/authentication/allowed_hosts_validator.go
+++ b/authentication/allowed_hosts_validator.go
@@ -73,5 +73,17 @@ func (v *AllowedHostsValidator) IsUrlHostValid(uri *u.URL) bool {
 	if host == "" {
 		return false
 	}
-	return len(v.validHosts) == 0 || v.validHosts[strings.ToLower(host)]
+	if len(v.validHosts) == 0 {
+		return true
+	}
+	lowerHost := strings.ToLower(host)
+	if v.validHosts[lowerHost] {
+		return true
+	}
+	for validHost := range v.validHosts {
+		if strings.HasPrefix(validHost, ".") && strings.HasSuffix(lowerHost, validHost) {
+			return true
+		}
+	}
+	return false
 }

--- a/authentication/allowed_hosts_validator_test.go
+++ b/authentication/allowed_hosts_validator_test.go
@@ -14,6 +14,54 @@ func TestItValidatesHostsUseNewAllowedHostsValidator(t *testing.T) {
 	assert.True(t, validator.IsUrlHostValid(url))
 }
 
+func TestItValidatesSubdomainMatchingAllowedSuffix(t *testing.T) {
+	validator := NewAllowedHostsValidator([]string{".fabric.microsoft.com"})
+	url, err := u.Parse("https://abc.123.graphql.fabric.microsoft.com/path")
+	assert.Nil(t, err)
+	assert.True(t, validator.IsUrlHostValid(url))
+}
+
+func TestItRejectsBareDomainWhenAllowedAsSuffix(t *testing.T) {
+	validator := NewAllowedHostsValidator([]string{".fabric.microsoft.com"})
+	url, err := u.Parse("https://fabric.microsoft.com/path")
+	assert.Nil(t, err)
+	assert.False(t, validator.IsUrlHostValid(url))
+}
+
+func TestItValidatesSuffixHostCaseInsensitively(t *testing.T) {
+	validator := NewAllowedHostsValidator([]string{".Fabric.Microsoft.COM"})
+	url, err := u.Parse("https://ABC.z2c.graphql.fabric.microsoft.com/path")
+	assert.Nil(t, err)
+	assert.True(t, validator.IsUrlHostValid(url))
+}
+
+func TestItAllowsMultipleValidHostsWithSuffixes(t *testing.T) {
+	validator := NewAllowedHostsValidator([]string{"example.com", "api.example.com", ".fabric.microsoft.com"})
+	testCases := []struct {
+		url      string
+		expected bool
+	}{
+		{"https://example.com/path", true},
+		{"https://api.example.com/path", true},
+		{"https://other.com/path", false},
+		{"https://abc.123.graphql.fabric.microsoft.com/path", true},
+	}
+
+	for _, testCase := range testCases {
+		url, err := u.Parse(testCase.url)
+		assert.Nil(t, err)
+		assert.Equal(t, testCase.expected, validator.IsUrlHostValid(url))
+	}
+}
+
+func TestItAllowsSuffixBasedHostsAfterUpdate(t *testing.T) {
+	validator := NewAllowedHostsValidator([]string{"example.com"})
+	validator.SetAllowedHosts([]string{".fabric.microsoft.com"})
+	url, err := u.Parse("https://abc.123.graphql.fabric.microsoft.com/path")
+	assert.Nil(t, err)
+	assert.True(t, validator.IsUrlHostValid(url))
+}
+
 func TestItValidatesHostsUseNewAllowedHostsValidatorErrorCheck(t *testing.T) {
 	validator, err := NewAllowedHostsValidatorErrorCheck([]string{"http://graph.microsoft.com"})
 	assert.EqualValues(t, ErrInvalidHostPrefix, err)


### PR DESCRIPTION
port of https://github.com/microsoft/kiota-python/pull/701 to go