### PR TITLE
fix: stop dropping scalar numeric query parameters

### DIFF
--- a/request_information.go
+++ b/request_information.go
@@ -624,7 +624,10 @@ func (request *RequestInformation) AddQueryParameters(source any) {
 		}
 		it, ok := value.(*int32)
 		if ok && it != nil {
+			// rendered into the deprecated QueryParameters map only; QueryParametersAny is
+			// documented to stay empty for it, so don't let it reach normalizeParameters
 			request.QueryParameters[fieldName] = strconv.FormatInt(int64(*it), 10)
+			continue
 		}
 		strArr, ok := value.([]string)
 		if ok && len(strArr) > 0 {
@@ -676,10 +679,8 @@ func (request *RequestInformation) normalizeParameters(valueOfValue reflect.Valu
 	} else if enum, ok := value.(kiotaEnum); ok {
 		return enum.String()
 	} else if valueOfValue.Kind() == reflect.Pointer && !valueOfValue.IsNil() {
-		// *int32 is not listed: AddQueryParameters already renders it into QueryParameters
-		// and QueryParametersAny is documented to stay empty for it
 		switch elem := valueOfValue.Elem(); elem.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int64,
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 			reflect.Float32, reflect.Float64:
 			return elem.Interface()

--- a/request_information.go
+++ b/request_information.go
@@ -654,6 +654,7 @@ func (request *RequestInformation) AddQueryParameters(source any) {
 // enum -> string (name)
 // []enum -> []string (containing names)
 // []non_interface -> []any (like []int64 -> []any)
+// *numeric -> numeric (like *int64 -> int64)
 func (request *RequestInformation) normalizeParameters(valueOfValue reflect.Value, value any, returnNilIfNotNormalizable bool) any {
 	if valueOfValue.Kind() == reflect.Slice && valueOfValue.Len() > 0 {
 		//type assertions to "enums" don't work if you don't know the enum type in advance, we need to use reflection
@@ -674,6 +675,15 @@ func (request *RequestInformation) normalizeParameters(valueOfValue reflect.Valu
 		}
 	} else if enum, ok := value.(kiotaEnum); ok {
 		return enum.String()
+	} else if valueOfValue.Kind() == reflect.Pointer && !valueOfValue.IsNil() {
+		// *int32 is not listed: AddQueryParameters already renders it into QueryParameters
+		// and QueryParametersAny is documented to stay empty for it
+		switch elem := valueOfValue.Elem(); elem.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+			reflect.Float32, reflect.Float64:
+			return elem.Interface()
+		}
 	}
 
 	if returnNilIfNotNormalizable {

--- a/request_information_test.go
+++ b/request_information_test.go
@@ -28,6 +28,12 @@ type QueryParameters struct {
 	Id             *uuid.UUID
 }
 
+type numericQueryParameters struct {
+	Limit  *int64   `uriparametername:"limit"`
+	Offset *int32   `uriparametername:"offset"`
+	Ratio  *float64 `uriparametername:"ratio"`
+}
+
 func TestItAddsStringQueryParameters(t *testing.T) {
 	requestInformation := NewRequestInformation()
 	value := "somefilter"
@@ -60,6 +66,49 @@ func TestItAddsIntQueryParameters(t *testing.T) {
 	requestInformation.AddQueryParameters(queryParameters)
 	assert.Equal(t, "42", requestInformation.QueryParameters["Top"])
 	assert.Nil(t, requestInformation.QueryParametersAny["Top"])
+}
+
+func TestItAddsInt64QueryParameters(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	value := int64(42)
+	queryParameters := numericQueryParameters{
+		Limit: &value,
+	}
+	requestInformation.AddQueryParameters(queryParameters)
+	assert.Equal(t, int64(42), requestInformation.QueryParametersAny["limit"])
+}
+
+func TestItAddsFloat64QueryParameters(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	value := 1.5
+	queryParameters := numericQueryParameters{
+		Ratio: &value,
+	}
+	requestInformation.AddQueryParameters(queryParameters)
+	assert.Equal(t, 1.5, requestInformation.QueryParametersAny["ratio"])
+}
+
+func TestItSetsScalarNumericQueryParameters(t *testing.T) {
+	limit, offset, ratio := int64(10), int32(20), 1.5
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/items{?limit*,offset*,ratio*}"
+	requestInformation.AddQueryParameters(numericQueryParameters{
+		Limit:  &limit,
+		Offset: &offset,
+		Ratio:  &ratio,
+	})
+	resultUri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost/items?limit=10&offset=20&ratio=1.5", resultUri.String())
+}
+
+func TestItDoesNotSetNilNumericQueryParameters(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/items{?limit*}"
+	requestInformation.AddQueryParameters(numericQueryParameters{})
+	resultUri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost/items", resultUri.String())
 }
 
 func TestItAddsStringArrayQueryParameters(t *testing.T) {

--- a/request_information_test.go
+++ b/request_information_test.go
@@ -180,6 +180,20 @@ func TestItSetsUUIDPathParameters(t *testing.T) {
 	assert.Equal(t, "http://localhost/users/95e943b8-52d5-4228-902d-61d65792ced7", resultUri.String())
 }
 
+func TestItSetsScalarNumericPathParameters(t *testing.T) {
+	requestInformation := NewRequestInformation()
+	requestInformation.UrlTemplate = "http://localhost/items/{limit}/{offset}/{ratio}"
+	limit := int64(10)
+	offset := int32(20)
+	ratio := 1.5
+	requestInformation.PathParametersAny["limit"] = &limit
+	requestInformation.PathParametersAny["offset"] = &offset
+	requestInformation.PathParametersAny["ratio"] = &ratio
+	resultUri, err := requestInformation.GetUri()
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost/items/10/20/1.5", resultUri.String())
+}
+
 func TestItSetsNumberArrayQueryParameters(t *testing.T) {
 	requestInformation := NewRequestInformation()
 	requestInformation.UrlTemplate = "http://localhost/me{?%24number}"


### PR DESCRIPTION
## Description

Fixes #264.

A query parameter that kiota generates as `*int64` (from `format: int64`) or `*float64`
(from `format: double`) never reaches the URL. No error, no warning, no log: the value is
accepted by the request builder and is simply absent from the request. For a spec declaring
`limit` as `format: int64` and `offset` as `format: int32`, only `offset` is sent — and the
difference between "the page I asked for" and "the default page" passes unnoticed.

`AddQueryParameters` matches a fixed set of types (`*string`, `*bool`, `*int32`, `[]string`,
`[]any`, maps), and everything else rides on `normalizeParameters` — which only handled
slices and enums. A scalar pointer to any other numeric type matched nothing, the
`returnNilIfNotNormalizable` branch returned `nil`, and the field was skipped without a
trace. Affected the same way: `*int8`, `*int16`, `*int64`, `*uint` and friends, `*float32`,
`*float64`.

This is the scalar counterpart of #124 ("Parameters with lists of numbers not supported in
URIs"), which fixed the *slice* case by routing `[]int64` and friends through
`QueryParametersAny`.

## Changes

One addition to `normalizeParameters` in `request_information.go`: a non-nil pointer whose
element is of a numeric `reflect.Kind` is dereferenced and returned, so `AddQueryParameters`
puts the value in `QueryParametersAny` exactly like it already does for numeric slices. The
uri template layer renders numbers natively, so nothing else has to change.

`*int32` needs one extra step, because `AddQueryParameters` already renders it into the
(deprecated) `QueryParameters` map and `TestItAddsIntQueryParameters` pins
`QueryParametersAny` staying empty for it. Rather than exclude `reflect.Int32` from
`normalizeParameters` — which would leak a query-parameter concern into a helper that
`GetUri` also uses for `PathParametersAny` — the `*int32` branch of `AddQueryParameters`
short-circuits with a `continue`. Nothing below it in the loop can match a `*int32`, so the
query-side contract is left untouched either way.

That distinction is not cosmetic: `normalizeParameters` is shared, and an un-normalized
pointer reaching `stduritemplate.Expand` is dropped rather than rendered. With `reflect.Int32`
excluded, a `*int32` **path** parameter disappears from the URL —
`/items/{limit}/{offset}/{ratio}` renders as `/items/10//1.5` — which is the same silent drop
this PR is about, on the path side. Handling every numeric kind uniformly fixes that too.

Enums are unaffected: the enum check runs first, so a pointer to an int-backed enum still
renders as its name, not its number.

## Testing

- `go vet ./...` and `go test ./...` pass, all packages.
- New tests:
  - `TestItAddsInt64QueryParameters` / `TestItAddsFloat64QueryParameters` — the value lands
    in `QueryParametersAny` under the `uriparametername` key.
  - `TestItSetsScalarNumericQueryParameters` — the reproduction from #264 as a test:
    `*int64`, `*int32` and `*float64` together, asserting the built URL is
    `http://localhost/items?limit=10&offset=20&ratio=1.5`. Before the fix `limit` and
    `ratio` are missing from that URL.
  - `TestItDoesNotSetNilNumericQueryParameters` — a nil pointer still renders nothing.
  - `TestItSetsScalarNumericPathParameters` — the same three types as path parameters via
    `PathParametersAny`, asserting `http://localhost/items/10/20/1.5`. Fails without the
    `reflect.Int32` case.
- `TestItAddsIntQueryParameters` is unchanged and still passes, pinning the `*int32`
  query-parameter contract.

---

Generated with Claude Code

